### PR TITLE
rc2.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SPHKernels"
 uuid = "54ab9b88-2582-4358-b400-8014666a1730"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "2.2.0"
+version = "2.3.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -11,7 +11,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Documenter = "0.25, 0.26, 0.27"
+Documenter = "0.25, 0.26, 0.27, 1"
 DocumenterTools = "0.1"
 PrecompileTools = "1"
 julia = "1.6"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -7,20 +7,40 @@ version = "0.0.1"
 
 [[AbstractFFTs]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "485ee0867925449198280d4af84bdb46a2a404d0"
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.0.1"
+version = "1.5.0"
+weakdeps = ["ChainRulesCore", "Test"]
+
+    [AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
 
 [[AbstractTrees]]
-git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-version = "0.3.4"
+version = "0.4.5"
 
 [[Adapt]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+deps = ["LinearAlgebra", "Requires"]
+git-tree-sha1 = "6a55b747d1812e699320963ffde36f1ebdda4099"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.3.1"
+version = "4.0.4"
+weakdeps = ["StaticArrays"]
+
+    [Adapt.extensions]
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[AdaptivePredicates]]
+git-tree-sha1 = "7e651ea8d262d2d74ce75fdf47c4d63c07dba7a6"
+uuid = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
+version = "1.2.0"
+
+[[AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
 
 [[Animations]]
 deps = ["Colors"]
@@ -30,71 +50,88 @@ version = "0.4.1"
 
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-
-[[ArrayInterface]]
-deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "e527b258413e0c6d4f66ade574744c94edef81f8"
-uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.40"
+version = "1.1.2"
 
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[Automa]]
-deps = ["Printf", "ScanByte", "TranscodingStreams"]
-git-tree-sha1 = "d50976f217489ce799e366d9561d56a98a30d7fe"
+deps = ["PrecompileTools", "TranscodingStreams"]
+git-tree-sha1 = "014bc22d6c400a7703c0f5dc1fdc302440cf88be"
 uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
-version = "0.8.2"
+version = "1.0.4"
 
 [[AxisAlgorithms]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "WoodburyMatrices"]
-git-tree-sha1 = "66771c8d21c8ff5e3a93379480a2307ac36863f7"
+git-tree-sha1 = "01b8ccb13d68535d73d2b0c23e39bd23155fb712"
 uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
-version = "1.0.1"
+version = "1.1.0"
+
+[[AxisArrays]]
+deps = ["Dates", "IntervalSets", "IterTools", "RangeArrays"]
+git-tree-sha1 = "16351be62963a67ac4083f748fdb3cca58bfd52f"
+uuid = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+version = "0.4.7"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
+git-tree-sha1 = "9e2a6b69137e6969bab0152632dcb3bc108c8bdd"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.8+0"
+version = "1.0.8+1"
 
 [[CEnum]]
-git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-version = "0.4.1"
+version = "0.5.0"
+
+[[CRC32c]]
+uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+version = "1.11.0"
+
+[[CRlibm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e329286945d0cfc04456972ea732551869af1cfc"
+uuid = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
+version = "1.0.1+0"
 
 [[Cairo]]
 deps = ["Cairo_jll", "Colors", "Glib_jll", "Graphics", "Libdl", "Pango_jll"]
-git-tree-sha1 = "d0b3f8b4ad16cb0a2988c6788646a5e6a17b6b1b"
+git-tree-sha1 = "7b6ad8c35f4bc3bca8eb78127c8b99719506a5fb"
 uuid = "159f3aea-2a34-519c-b102-8c37f9878175"
-version = "1.0.5"
+version = "1.1.0"
 
 [[CairoMakie]]
-deps = ["Base64", "Cairo", "Colors", "FFTW", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "SHA", "StaticArrays"]
-git-tree-sha1 = "774ff1cce3ae930af3948c120c15eeb96c886c33"
+deps = ["CRC32c", "Cairo", "Cairo_jll", "Colors", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "PrecompileTools"]
+git-tree-sha1 = "2b04b60ed9d3e977f93e34952971b608c34b3401"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.6.6"
+version = "0.12.13"
 
 [[Cairo_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "f2202b55d816427cd385a9a4f3ffb226bee80f99"
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "009060c9a6168704143100f36ab08f06c2af4642"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
-version = "1.16.1+0"
+version = "1.18.2+1"
 
 [[ChainRulesCore]]
-deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "f885e7e7c124f8c92650d61b9477b9ac2ee607dd"
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "3e4b134270b372f2ed4d4d0e936aabaefc1802bc"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.11.1"
+version = "1.25.0"
+weakdeps = ["SparseArrays"]
 
-[[ChangesOfVariables]]
-deps = ["LinearAlgebra", "Test"]
-git-tree-sha1 = "9a1d594397670492219635b35a3d830b04730d62"
-uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.1"
+    [ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.6"
 
 [[ColorBrewer]]
 deps = ["Colors", "JSON", "Test"]
@@ -103,55 +140,74 @@ uuid = "a2cac450-b92f-5266-8821-25eda20663c8"
 version = "0.4.0"
 
 [[ColorSchemes]]
-deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random"]
-git-tree-sha1 = "a851fec56cb73cfdf43762999ec72eff5b86882a"
+deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
+git-tree-sha1 = "b5278586822443594ff615963b0c09755771b3e0"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.15.0"
+version = "3.26.0"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
+git-tree-sha1 = "b10d0b65641d57b8b4d5e234446582de5047050d"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.0"
+version = "0.11.5"
 
 [[ColorVectorSpace]]
-deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "SpecialFunctions", "Statistics", "TensorCore"]
-git-tree-sha1 = "45efb332df2e86f2cb2e992239b6267d97c9e0b6"
+deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "Requires", "Statistics", "TensorCore"]
+git-tree-sha1 = "a1f44953f2382ebb937d60dafbe2deea4bd23249"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.9.7"
+version = "0.10.0"
+weakdeps = ["SpecialFunctions"]
+
+    [ColorVectorSpace.extensions]
+    SpecialFunctionsExt = "SpecialFunctions"
 
 [[Colors]]
 deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
-git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
+git-tree-sha1 = "362a287c3aa50601b0bc359053d5c2468f0e7ce0"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.8"
+version = "0.12.11"
 
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dce3e3fea680869eaa0b774b2e8343e9ff442313"
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.40.0"
+version = "4.16.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[ConstructionBase]]
+git-tree-sha1 = "76219f1ed5771adbb096743bff43fb5fdd4c1157"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.5.8"
+weakdeps = ["IntervalSets", "LinearAlgebra", "StaticArrays"]
+
+    [ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [[Contour]]
-deps = ["StaticArrays"]
-git-tree-sha1 = "9f02045d934dc030edad45944ea80dbd1f0ebea7"
+git-tree-sha1 = "439e35b0b36e2e5881738abc8857bd92ad6ff9a8"
 uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
-version = "0.5.7"
+version = "0.6.3"
 
 [[DataAPI]]
-git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.9.0"
+version = "1.16.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
+git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.10"
+version = "0.18.20"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -161,144 +217,194 @@ version = "1.0.0"
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
-[[DelimitedFiles]]
-deps = ["Mmap"]
-uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[DensityInterface]]
-deps = ["InverseFunctions", "Test"]
-git-tree-sha1 = "794daf62dce7df839b8ed446fc59c68db4b5182f"
-uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
-version = "0.3.3"
+[[DelaunayTriangulation]]
+deps = ["AdaptivePredicates", "EnumX", "ExactPredicates", "PrecompileTools", "Random"]
+git-tree-sha1 = "668bb97ea6df5e654e6288d87d2243591fe68665"
+uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
+version = "1.6.0"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
 
 [[Distributions]]
-deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "cab6fd4d6a0fca4d7f1dcdc2a130884e6ae242c9"
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "d7477ecdafb813ddee2ae727afa94e9dcb5f3fb0"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.28"
+version = "0.25.112"
+
+    [Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsTestExt = "Test"
+
+    [Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.6"
+version = "0.9.3"
 
 [[Documenter]]
-deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "f425293f7e0acaf9144de6d731772de156676233"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "5a1ee886566f2fa9318df1273d8b778b9d42712d"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.10"
+version = "1.7.0"
 
 [[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
 
 [[EarCut_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "3f3a2501fa7236e9b911e0f7a588c657e822bb6d"
+git-tree-sha1 = "e3290f2d49e661fbd94046d7e3726ffcb2d41053"
 uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
-version = "2.2.3+0"
+version = "2.2.4+0"
 
-[[EllipsisNotation]]
-deps = ["ArrayInterface"]
-git-tree-sha1 = "9aad812fb7c4c038da7cab5a069f502e6e3ae030"
-uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
-version = "1.1.1"
+[[EnumX]]
+git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.4"
+
+[[ExactPredicates]]
+deps = ["IntervalArithmetic", "Random", "StaticArrays"]
+git-tree-sha1 = "b3f2ff58735b5f024c392fde763f29b057e4b025"
+uuid = "429591f6-91af-11e9-00e2-59fbe8cec110"
+version = "2.2.8"
 
 [[Expat_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1c6317308b9dc757616f0b5cb379db10494443a7"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.2.10+0"
+version = "2.6.2+0"
 
-[[FFMPEG]]
-deps = ["FFMPEG_jll"]
-git-tree-sha1 = "b57e3acbe22f8484b4b5ff66a7499717fe1a9cc8"
-uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.4.1"
+[[Extents]]
+git-tree-sha1 = "81023caa0021a41712685887db1fc03db26f41f5"
+uuid = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+version = "0.1.4"
 
 [[FFMPEG_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "d8a578692e3077ac998b50c0217dfd67f21d1e5f"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "8cc47f299902e13f90405ddb5bf87e5d474c0d38"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "4.4.0+0"
+version = "6.1.2+0"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
-git-tree-sha1 = "463cb335fa22c4ebacfd1faba5fde14edb80d96c"
+git-tree-sha1 = "4820348781ae578893311153d69049a93d05f39d"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.4.5"
+version = "1.8.0"
 
 [[FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
+git-tree-sha1 = "4d81ed14783ec49ce9f2e168208a12ce1815aa25"
 uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.10+0"
+version = "3.3.10+1"
 
 [[FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "2db648b6712831ecb333eae76dbfd1c156ca13bb"
+git-tree-sha1 = "82d8afa92ecf4b52d78d869f038ebfb881267322"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.11.2"
+version = "1.16.3"
+
+[[FilePaths]]
+deps = ["FilePathsBase", "MacroTools", "Reexport", "Requires"]
+git-tree-sha1 = "919d9412dbf53a2e6fe74af62a73ceed0bce0629"
+uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
+version = "0.8.3"
+
+[[FilePathsBase]]
+deps = ["Compat", "Dates"]
+git-tree-sha1 = "7878ff7172a8e6beedd1dea14bd27c3c6340d361"
+uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
+version = "0.9.22"
+weakdeps = ["Mmap", "Test"]
+
+    [FilePathsBase.extensions]
+    FilePathsBaseMmapExt = "Mmap"
+    FilePathsBaseTestExt = "Test"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "8756f9935b7ccc9064c6eef0bff0ad643df733a3"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "6a70198746448456524cb442b8af316927ff3e1a"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.7"
+version = "1.13.0"
+weakdeps = ["PDMats", "SparseArrays", "Statistics"]
+
+    [FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStatisticsExt = "Statistics"
 
 [[FixedPointNumbers]]
 deps = ["Statistics"]
-git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+git-tree-sha1 = "05882d6995ae5c12bb5f36dd2ed3f61c98cbb172"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.8.4"
+version = "0.8.5"
 
 [[Fontconfig_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "21efd19106a55620a188615da6d3d06cd7f6ee03"
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Zlib_jll"]
+git-tree-sha1 = "db16beca600632c95fc8aca29890d83788dd8b23"
 uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
-version = "2.13.93+0"
+version = "2.13.96+0"
 
-[[Formatting]]
-deps = ["Printf"]
-git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
-uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
-version = "0.4.2"
+[[Format]]
+git-tree-sha1 = "9c68794ef81b08086aeb32eeaf33531668d5f5fc"
+uuid = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+version = "1.3.7"
 
 [[FreeType]]
 deps = ["CEnum", "FreeType2_jll"]
-git-tree-sha1 = "cabd77ab6a6fdff49bfd24af2ebe76e6e018a2b4"
+git-tree-sha1 = "907369da0f8e80728ab49c1c7e09327bf0d6d999"
 uuid = "b38be410-82b0-50bf-ab77-7b57e271db43"
-version = "4.0.0"
+version = "4.1.1"
 
 [[FreeType2_jll]]
-deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "87eb71354d8ec1a96d4a7636bd57a7347dde3ef9"
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "5c1d8ae0efc6c2e7b1fc502cbe25def8f661b7bc"
 uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
-version = "2.10.4+0"
+version = "2.13.2+0"
 
 [[FreeTypeAbstraction]]
-deps = ["ColorVectorSpace", "Colors", "FreeType", "GeometryBasics", "StaticArrays"]
-git-tree-sha1 = "19d0f1e234c13bbfd75258e55c52aa1d876115f5"
+deps = ["ColorVectorSpace", "Colors", "FreeType", "GeometryBasics"]
+git-tree-sha1 = "2493cdfd0740015955a8e46de4ef28f49460d8bc"
 uuid = "663a7486-cb36-511b-a19d-713bb74d65c9"
-version = "0.9.2"
+version = "0.10.3"
 
 [[FriBidi_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1ed150b39aebcc805c26b93a8d0122c940f64ce2"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
-version = "1.0.10+0"
+version = "1.0.14+0"
+
+[[GeoFormatTypes]]
+git-tree-sha1 = "59107c179a586f0fe667024c5eb7033e81333271"
+uuid = "68eda718-8dee-11e9-39e7-89f7f65f511f"
+version = "0.4.2"
+
+[[GeoInterface]]
+deps = ["Extents", "GeoFormatTypes"]
+git-tree-sha1 = "2f6fce56cdb8373637a6614e14a5768a88450de2"
+uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+version = "1.3.7"
 
 [[GeometryBasics]]
-deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "58bcdf5ebc057b085e58d95c138725628dd7453c"
+deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "b62f2b2d76cee0d61a2ef2b3118cd2a3215d3134"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.4.1"
+version = "0.4.11"
 
 [[Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -306,17 +412,29 @@ git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
 uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
 version = "0.21.0+0"
 
+[[Git]]
+deps = ["Git_jll"]
+git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.3.1"
+
+[[Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.46.2+0"
+
 [[Glib_jll]]
-deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "7bf67e9a481712b3dbe9cb3dac852dc4b1162e02"
+deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "674ff0db93fffcd11a3573986e550d66cd4fd71f"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.68.3+0"
+version = "2.80.5+0"
 
 [[Graphics]]
 deps = ["Colors", "LinearAlgebra", "NaNMath"]
-git-tree-sha1 = "1c5a84319923bea76fa145d49e93aa4394c73fc2"
+git-tree-sha1 = "d61890399bc535850c4bf08e4e0d3a7ad0f21cbd"
 uuid = "a2bd30eb-e257-5431-a919-1863eab51364"
-version = "1.1.1"
+version = "1.1.2"
 
 [[Graphite2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -326,9 +444,9 @@ version = "1.3.14+0"
 
 [[GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
-git-tree-sha1 = "70938436e2720e6cb8a7f2ca9f1bbdbf40d7f5d0"
+git-tree-sha1 = "fc713f007cff99ff9e50accba6373624ddd33588"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
-version = "0.6.4"
+version = "0.11.0"
 
 [[Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
@@ -336,39 +454,58 @@ uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 version = "1.0.2"
 
 [[HarfBuzz_jll]]
-deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
-git-tree-sha1 = "8a954fed8ac097d5be04921d595f741115c1b2ad"
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "401e4f3f30f43af2c8478fc008da50096ea5240f"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "2.8.1+0"
+version = "8.3.1+0"
+
+[[HypergeometricFunctions]]
+deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "7c4195be1649ae622304031ed46a2f4df989f1eb"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.24"
 
 [[IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+git-tree-sha1 = "b6d6bfdd7ce25b0f9b2f6b3dd56b2673a66c8770"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.2"
+version = "0.2.5"
 
-[[IfElse]]
-git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
-uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
-version = "0.1.1"
+[[ImageAxes]]
+deps = ["AxisArrays", "ImageBase", "ImageCore", "Reexport", "SimpleTraits"]
+git-tree-sha1 = "2e4520d67b0cef90865b3ef727594d2a58e0e1f8"
+uuid = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
+version = "0.6.11"
+
+[[ImageBase]]
+deps = ["ImageCore", "Reexport"]
+git-tree-sha1 = "eb49b82c172811fd2c86759fa0553a2221feb909"
+uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
+version = "0.1.7"
 
 [[ImageCore]]
-deps = ["AbstractFFTs", "ColorVectorSpace", "Colors", "FixedPointNumbers", "Graphics", "MappedArrays", "MosaicViews", "OffsetArrays", "PaddedViews", "Reexport"]
-git-tree-sha1 = "9a5c62f231e5bba35695a20988fc7cd6de7eeb5a"
+deps = ["ColorVectorSpace", "Colors", "FixedPointNumbers", "MappedArrays", "MosaicViews", "OffsetArrays", "PaddedViews", "PrecompileTools", "Reexport"]
+git-tree-sha1 = "b2a7eaa169c13f5bcae8131a83bc30eff8f71be0"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.9.3"
+version = "0.10.2"
 
 [[ImageIO]]
-deps = ["FileIO", "Netpbm", "OpenEXR", "PNGFiles", "TiffImages", "UUIDs"]
-git-tree-sha1 = "a2951c93684551467265e0e32b577914f69532be"
+deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs"]
+git-tree-sha1 = "437abb322a41d527c197fa800455f79d414f0a3c"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
-version = "0.5.9"
+version = "0.6.8"
+
+[[ImageMetadata]]
+deps = ["AxisArrays", "ImageAxes", "ImageBase", "ImageCore"]
+git-tree-sha1 = "355e2b974f2e3212a75dfb60519de21361ad3cb7"
+uuid = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+version = "0.9.9"
 
 [[Imath_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "87f7662e03a649cffa2e05bf19c303e168732d3e"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "0936ba688c6d201805a83da835b55c61a180db52"
 uuid = "905a6f67-0a94-5f89-b386-d35d92009cd1"
-version = "3.1.2+0"
+version = "3.1.11+0"
 
 [[IndirectArrays]]
 git-tree-sha1 = "012e604e1c7458645cb8b436f8fba789a51b257f"
@@ -376,42 +513,70 @@ uuid = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 version = "1.0.0"
 
 [[Inflate]]
-git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
+git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
 uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
-version = "0.1.2"
+version = "0.1.5"
 
 [[IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "d979e54b71da82f3a65b62553da4fc3d18c9004c"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "10bd689145d2c3b2a9844005d01087cc1194e79e"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2018.0.3+2"
+version = "2024.2.1+0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[Interpolations]]
-deps = ["AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
-git-tree-sha1 = "61aa005707ea2cebf47c8d780da8dc9bc4e0c512"
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "88a101217d7cb38a7b481ccd50d21876e1d1b0e0"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.13.4"
+version = "0.15.1"
+weakdeps = ["Unitful"]
+
+    [Interpolations.extensions]
+    InterpolationsUnitfulExt = "Unitful"
+
+[[IntervalArithmetic]]
+deps = ["CRlibm_jll", "MacroTools", "RoundingEmulator"]
+git-tree-sha1 = "8e125d40cae3a9f4276cdfeb4fcdb1828888a4b3"
+uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+version = "0.22.17"
+
+    [IntervalArithmetic.extensions]
+    IntervalArithmeticDiffRulesExt = "DiffRules"
+    IntervalArithmeticForwardDiffExt = "ForwardDiff"
+    IntervalArithmeticIntervalSetsExt = "IntervalSets"
+    IntervalArithmeticLinearAlgebraExt = "LinearAlgebra"
+    IntervalArithmeticRecipesBaseExt = "RecipesBase"
+
+    [IntervalArithmetic.weakdeps]
+    DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [[IntervalSets]]
-deps = ["Dates", "EllipsisNotation", "Statistics"]
-git-tree-sha1 = "3cc368af3f110a767ac786560045dceddfc16758"
+git-tree-sha1 = "dba9ddf07f77f60450fe5d2e2beb9854d9a49bd0"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.5.3"
+version = "0.7.10"
 
-[[InverseFunctions]]
-deps = ["Test"]
-git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
-uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.2"
+    [IntervalSets.extensions]
+    IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
+    IntervalSetsStatisticsExt = "Statistics"
+
+    [IntervalSets.weakdeps]
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[IrrationalConstants]]
-git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.1"
+version = "0.2.2"
 
 [[Isoband]]
 deps = ["isoband_jll"]
@@ -420,9 +585,9 @@ uuid = "f1662d9f-8043-43de-a69a-05efc1cc6ff4"
 version = "0.1.1"
 
 [[IterTools]]
-git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+git-tree-sha1 = "42d5f897009e7ff2cf88db414a389e5ed1bdd023"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.3.0"
+version = "1.10.0"
 
 [[IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -430,62 +595,101 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "f389674c99bfcde17dc57454011aa44d5a260a40"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.3.0"
+version = "1.6.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.2"
+version = "0.21.4"
+
+[[JpegTurbo]]
+deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
+git-tree-sha1 = "fa6d0bcff8583bac20f1ffa708c3913ca605c611"
+uuid = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
+version = "0.1.5"
+
+[[JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "25ee0be4d43d0269027024d75a24c24d6c6e590c"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "3.0.4+0"
 
 [[KernelDensity]]
 deps = ["Distributions", "DocStringExtensions", "FFTW", "Interpolations", "StatsBase"]
-git-tree-sha1 = "591e8dc09ad18386189610acafb970032c519707"
+git-tree-sha1 = "7d703202e65efa1369de1279c162b915e245eed1"
 uuid = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
-version = "0.6.3"
+version = "0.6.9"
 
 [[LAME_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f6250b16881adf048549549fba48b1161acdac8c"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "170b660facf5df5de098d866564877e119141cbd"
 uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
-version = "3.100.1+0"
+version = "3.100.2+0"
+
+[[LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "18.1.7+0"
 
 [[LZO_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e5b909bcf985c5e2605737d2ce278ed791b89be6"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "854a9c268c43b77b0a27f22d7fab8d33cdb3a731"
 uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
-version = "2.10.1+0"
+version = "2.10.2+1"
 
 [[LaTeXStrings]]
-git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
+git-tree-sha1 = "50901ebc375ed41dbf8058da26f9de442febbbec"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.3.0"
+version = "1.3.1"
+
+[[LazilyInitializedFields]]
+git-tree-sha1 = "8f7f3cabab0fd1800699663533b6d5cb3fc0e612"
+uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
+version = "1.2.2"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[LazyModules]]
+git-tree-sha1 = "a560dd966b386ac9ae60bdd3a3d3a326062d3c3e"
+uuid = "8cdb02fc-e678-4876-92c5-9defec4f444e"
+version = "0.3.1"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
 
 [[LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
 
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
 
 [[LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[Libffi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -494,138 +698,171 @@ uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
 version = "3.2.2+1"
 
 [[Libgcrypt_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
-git-tree-sha1 = "64613c82a59c120435c067c2b809fc61cf5166ae"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll"]
+git-tree-sha1 = "9fd170c4bbfd8b935fdc5f8b7aa33532c991a673"
 uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
-version = "1.8.7+0"
+version = "1.8.11+0"
 
 [[Libgpg_error_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c333716e46366857753e273ce6a69ee0945a6db9"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "fbb1f2bef882392312feb1ede3615ddc1e9b99ed"
 uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
-version = "1.42.0+0"
+version = "1.49.0+0"
 
 [[Libiconv_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.17.0+0"
 
 [[Libmount_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9c30530bf0effd46e15e0fdcf2b8636e78cbbd73"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "0c4f9c4f1a50d8f35048fa0532dabbadf702f81e"
 uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
-version = "2.35.0+0"
+version = "2.40.1+0"
 
 [[Libuuid_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "7f3efec06033682db852f8b3bc3c1d2b0a0ab066"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "5ee6203157c120d79034c748a2acba45b82b8807"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
-version = "2.36.0+0"
+version = "2.40.1+0"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
 
 [[LogExpFunctions]]
-deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "be9eef9f9d78cecb6f262f3c10da151a6c5ab827"
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "a2d09619db4e765091ee5c6ffe8872849de0feea"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.5"
+version = "0.3.28"
+
+    [LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[MKL_jll]]
-deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "5455aef09b40e5020e1520f551fa3135040d4ed0"
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
+git-tree-sha1 = "f046ccd0c6db2832a9f639e2c669c6fe867e5f4f"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2021.1.1+2"
+version = "2024.2.0+0"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "2fa9ee3e63fd3a4f7a9a4f4744a52f4856de82df"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.13"
 
 [[Makie]]
-deps = ["Animations", "Base64", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Distributions", "DocStringExtensions", "FFMPEG", "FileIO", "FixedPointNumbers", "Formatting", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MakieCore", "Markdown", "Match", "MathTeXEngine", "Observables", "Packing", "PlotUtils", "PolygonOps", "Printf", "Random", "RelocatableFolders", "Serialization", "Showoff", "SignedDistanceFields", "SparseArrays", "StaticArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "UnicodeFun"]
-git-tree-sha1 = "56b0b7772676c499430dc8eb15cfab120c05a150"
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "50ebda951efaa11b6db0413c1128726b8eab3bf0"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.15.3"
+version = "0.21.13"
 
 [[MakieCore]]
-deps = ["Observables"]
-git-tree-sha1 = "7bcc8323fb37523a6a51ade2234eee27a11114c8"
+deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
+git-tree-sha1 = "4604f03e5b057e8e62a95a44929cafc9585b0fe9"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.1.3"
+version = "0.8.9"
 
 [[MappedArrays]]
-git-tree-sha1 = "e8b359ef06ec72e8c030463fe02efe5527ee5142"
+git-tree-sha1 = "2dab0221fe2b0f2cb6754eaa743cc266339f527e"
 uuid = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
-version = "0.4.1"
+version = "0.4.2"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
-[[Match]]
-git-tree-sha1 = "5cf525d97caf86d29307150fcba763a64eaa9cbe"
-uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
-version = "1.1.0"
+[[MarkdownAST]]
+deps = ["AbstractTrees", "Markdown"]
+git-tree-sha1 = "465a70f0fc7d443a00dcdc3267a497397b8a3899"
+uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+version = "0.1.2"
 
 [[MathTeXEngine]]
-deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "Test"]
-git-tree-sha1 = "70e733037bbf02d691e78f95171a1fa08cdc6332"
+deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
+git-tree-sha1 = "e1641f32ae592e415e3dbae7f4a188b5316d4b62"
 uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
-version = "0.2.1"
+version = "0.6.1"
 
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
 
 [[Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "1.0.2"
+version = "1.2.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[MosaicViews]]
 deps = ["MappedArrays", "OffsetArrays", "PaddedViews", "StackViews"]
-git-tree-sha1 = "b34e3bc3ca7c94914418637cb10cc4d1d80d877d"
+git-tree-sha1 = "7b86a5d4d70a9f5cdf2dacb3cbe6d251d1a61dbe"
 uuid = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
-version = "0.3.3"
+version = "0.3.4"
 
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
 
 [[NaNMath]]
-git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.5"
+version = "1.0.2"
 
 [[Netpbm]]
-deps = ["FileIO", "ImageCore"]
-git-tree-sha1 = "18efc06f6ec36a8b801b23f076e3c6ac7c3bf153"
+deps = ["FileIO", "ImageCore", "ImageMetadata"]
+git-tree-sha1 = "d92b107dbb887293622df7697a2223f9f8176fcd"
 uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
-version = "1.0.2"
+version = "1.1.1"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[Observables]]
-git-tree-sha1 = "fe29afdef3d0c4a8286128d4e45cc50621b1e43d"
+git-tree-sha1 = "7438a59546cf62428fc9d1bc94729146d37a7225"
 uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
-version = "0.4.0"
+version = "0.5.5"
 
 [[OffsetArrays]]
-deps = ["Adapt"]
-git-tree-sha1 = "043017e0bdeff61cfbb7afeb558ab29536bbb5ed"
+git-tree-sha1 = "1a27764e945a152f7ca7efa04de513d473e9542e"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.10.8"
+version = "1.14.1"
+weakdeps = ["Adapt"]
+
+    [OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
 
 [[Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "7937eda4681660b4d6aeeecc2f7e1c81c8ee4e2f"
+git-tree-sha1 = "887579a3eb005446d514ab7aeac5d1d027658b8f"
 uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
-version = "1.3.5+0"
+version = "1.3.5+1"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.27+1"
 
 [[OpenEXR]]
 deps = ["Colors", "FileIO", "OpenEXR_jll"]
@@ -634,20 +871,21 @@ uuid = "52e1d378-f018-4a11-a4be-720524705ac7"
 version = "0.3.2"
 
 [[OpenEXR_jll]]
-deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "923319661e9a22712f24596ce81c54fc0366f304"
+deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "8292dd5c8a38257111ada2174000a33745b06d4e"
 uuid = "18a262bb-aa17-5467-a713-aee519bc75cb"
-version = "3.1.1+0"
+version = "3.2.4+0"
 
 [[OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.1+2"
 
 [[OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "15003dcb7d8db3c6c857fda14891a539a8f2705a"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.10+0"
+version = "3.0.15+1"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -656,176 +894,230 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
 [[Opus_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "51a08fb14ec28da2ec7a927c4337e4332c2a4720"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6703a85cb3781bd5909d48730a67205f3f31a575"
 uuid = "91d4177d-7536-5919-b921-800302f37372"
-version = "1.3.2+0"
+version = "1.3.3+0"
 
 [[OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.6.3"
 
-[[PCRE_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b2a7af664e098055a7529ad1a900ded962bca488"
-uuid = "2f80f16e-611a-54ab-bc61-aa92de5b98fc"
-version = "8.44.0+0"
+[[PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.42.0+1"
 
 [[PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "c8b8775b2f242c80ea85c83714c64ecfa3c53355"
+git-tree-sha1 = "949347156c25054de2db3b166c52ac4728cbad65"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.3"
+version = "0.11.31"
 
 [[PNGFiles]]
 deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
-git-tree-sha1 = "6d105d40e30b635cfed9d52ec29cf456e27d38f8"
+git-tree-sha1 = "67186a2bc9a90f9f85ff3cc8277868961fb57cbd"
 uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
-version = "0.3.12"
+version = "0.4.3"
 
 [[Packing]]
 deps = ["GeometryBasics"]
-git-tree-sha1 = "1155f6f937fa2b94104162f01fa400e192e4272f"
+git-tree-sha1 = "ec3edfe723df33528e085e632414499f26650501"
 uuid = "19eb6ba3-879d-56ad-ad62-d5c202156566"
-version = "0.4.2"
+version = "0.5.0"
 
 [[PaddedViews]]
 deps = ["OffsetArrays"]
-git-tree-sha1 = "646eed6f6a5d8df6708f15ea7e02a7a2c4fe4800"
+git-tree-sha1 = "0fac6313486baae819364c52b4f483450a9d793f"
 uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
-version = "0.5.10"
+version = "0.5.12"
 
 [[Pango_jll]]
-deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9bc1871464b12ed19297fbc56c4fb4ba84988b0d"
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e127b609fb9ecba6f201ba7ab753d5a605d53801"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.47.0+0"
+version = "1.54.1+0"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "ae4bbcadb2906ccc085cf52ac286dc1377dceccc"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.1.2"
+version = "2.8.1"
 
 [[Pixman_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b4f5d02549a10e20780a24fce72bea96b6329e29"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
+git-tree-sha1 = "35621f10a7531bc8fa58f74610b1bfb70a3cfc6b"
 uuid = "30392449-352a-5448-841d-b1acce4e97dc"
-version = "0.40.1+0"
+version = "0.43.4+0"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.11.0"
+weakdeps = ["REPL"]
+
+    [Pkg.extensions]
+    REPLExt = "REPL"
 
 [[PkgVersion]]
 deps = ["Pkg"]
-git-tree-sha1 = "a7a7e1a88853564e551e4eba8650f8c38df79b37"
+git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
 uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
-version = "0.1.1"
+version = "0.3.3"
 
 [[PlotUtils]]
-deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "b084324b4af5a438cd63619fd006614b3b20b87b"
+deps = ["ColorSchemes", "Colors", "Dates", "PrecompileTools", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "7b1a9df27f072ac4c9c7cbe5efb198489258d1f5"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.15"
+version = "1.4.1"
 
 [[PolygonOps]]
 git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
 uuid = "647866c9-e3ac-4575-94e7-e3d426903924"
 version = "0.1.2"
 
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.4.3"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "afadeba63d90ff223a6a48d2009434ecee2ec9e8"
+git-tree-sha1 = "8f6bc219586aef8baf0ff9a5fe16ee9c70cb65e4"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.7.1"
+version = "1.10.2"
+
+[[PtrArrays]]
+git-tree-sha1 = "77a42d78b6a92df47ab37e177b2deac405e1c88f"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.2.1"
+
+[[QOI]]
+deps = ["ColorTypes", "FileIO", "FixedPointNumbers"]
+git-tree-sha1 = "18e8f4d1426e965c7b532ddd260599e1510d26ce"
+uuid = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
+version = "1.0.0"
 
 [[QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
+git-tree-sha1 = "cda3b045cf9ef07a08ad46731f5a3165e56cf3da"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.4.2"
+version = "2.11.1"
+
+    [QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[RangeArrays]]
+git-tree-sha1 = "b9039e93773ddcfc828f12aadf7115b4b4d225f5"
+uuid = "b3c3ace0-ae52-54e7-9d0b-2c1406fd6b9d"
+version = "0.3.2"
 
 [[Ratios]]
 deps = ["Requires"]
-git-tree-sha1 = "01d341f502250e81f6fec0afe662aa861392a3aa"
+git-tree-sha1 = "1342a47bf3260ee108163042310d26f2be5ec90b"
 uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
-version = "0.4.2"
+version = "0.4.5"
+weakdeps = ["FixedPointNumbers"]
+
+    [Ratios.extensions]
+    RatiosFixedPointNumbersExt = "FixedPointNumbers"
 
 [[Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
 
+[[RegistryInstances]]
+deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
+git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
+uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
+version = "0.1.0"
+
 [[RelocatableFolders]]
 deps = ["SHA", "Scratch"]
-git-tree-sha1 = "cdbd3b1338c72ce29d9584fdbe9e9b70eeb5adca"
+git-tree-sha1 = "ffdaf70d81cf6ff22c2b6e733c900c3321cab864"
 uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
-version = "0.1.3"
+version = "1.0.1"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.3.0"
 
 [[Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+git-tree-sha1 = "852bd0f55565a9e973fcfee83a84413270224dc4"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.0"
+version = "0.8.0"
 
 [[Rmath_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.3.0+0"
+version = "0.5.1+0"
+
+[[RoundingEmulator]]
+git-tree-sha1 = "40b9edad2e5287e05bd413a38f61a8ff55b9557b"
+uuid = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
+version = "0.2.1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[SIMD]]
-git-tree-sha1 = "9ba33637b24341aba594a2783a502760aa0bff04"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "98ca7c29edd6fc79cd74c61accb7010a4e7aee33"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
-version = "3.3.1"
-
-[[ScanByte]]
-deps = ["Libdl", "SIMD"]
-git-tree-sha1 = "9cc2955f2a254b18be655a4ee70bc4031b2b189e"
-uuid = "7b38b023-a4d7-4c5e-8d43-3f3097f304eb"
-version = "0.3.0"
+version = "3.6.0"
 
 [[Scratch]]
 deps = ["Dates"]
-git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+git-tree-sha1 = "3bac05bc7e74a75fd9cba4295cde4045d9fe2386"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
-version = "1.1.0"
+version = "1.2.1"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[ShaderAbstractions]]
+deps = ["ColorTypes", "FixedPointNumbers", "GeometryBasics", "LinearAlgebra", "Observables", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "79123bc60c5507f035e6d1d9e563bb2971954ec8"
+uuid = "65257c39-d410-5151-9873-9b3e5be5013e"
+version = "0.4.1"
 
 [[SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
 
 [[Showoff]]
 deps = ["Dates", "Grisu"]
@@ -839,24 +1131,42 @@ git-tree-sha1 = "d263a08ec505853a5ff1c1ebde2070419e3f28e9"
 uuid = "73760f76-fbc4-59ce-8f25-708e95d2df96"
 version = "0.4.0"
 
+[[SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.4"
+
+[[Sixel]]
+deps = ["Dates", "FileIO", "ImageCore", "IndirectArrays", "OffsetArrays", "REPL", "libsixel_jll"]
+git-tree-sha1 = "2da10356e31327c7096832eb9cd86307a50b1eb6"
+uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
+version = "0.1.3"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [[SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+git-tree-sha1 = "66e0a8e672a0bdfca2c3f5937efb8538b9ddc085"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.1"
+version = "1.2.1"
 
 [[SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.11.0"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "f0bccf98e16759818ffc5d97ac3ebf87eb950150"
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "2f5d4697f21388cbe1ff299430dd169ef97d7e14"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.8.1"
+version = "2.4.0"
+weakdeps = ["ChainRulesCore"]
+
+    [SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
 
 [[StackViews]]
 deps = ["OffsetArrays"]
@@ -864,52 +1174,93 @@ git-tree-sha1 = "46e589465204cd0c08b4bd97385e4fa79a0c770c"
 uuid = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
 version = "0.1.1"
 
-[[Static]]
-deps = ["IfElse"]
-git-tree-sha1 = "e7bc80dc93f50857a5d1e3c8121495852f407e6a"
-uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.4.0"
-
 [[StaticArrays]]
-deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "eeafab08ae20c62c44c8399ccb9354a04b80db50"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.13"
+version = "1.9.7"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[StaticArraysCore]]
+git-tree-sha1 = "192954ef1208c7019899fbf8049e717f92959682"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.3"
 
 [[Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
 
 [[StatsAPI]]
-git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "1ff449ad350c9c4cbc756624d6f8a8c3ef56d3ed"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.0.0"
+version = "1.7.0"
 
 [[StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "eb35dcc66558b2dda84079b9a1be17557d32091a"
+git-tree-sha1 = "5cf7606d6cef84b543b483848d4ae08ad9832b21"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.12"
+version = "0.34.3"
 
 [[StatsFuns]]
-deps = ["ChainRulesCore", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "385ab64e64e79f0cd7cfcf897169b91ebbb2d6c8"
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "b423576adc27097764a90e163157bcfc9acf0f46"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.13"
+version = "1.3.2"
+
+    [StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[StructArrays]]
-deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
-git-tree-sha1 = "2ce41e0d042c60ecd131e9fb7154a3bfadbf50d3"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.3"
+version = "0.6.18"
+
+    [StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
+[[SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.7.0+0"
+
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -918,14 +1269,15 @@ uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 version = "1.0.1"
 
 [[Tables]]
-deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "fed34d0e71b91734bf0a7e10eb1bb05296ddbcd0"
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "598cd7c1f68d1e205689b1c2fe65a9f85846f297"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.6.0"
+version = "1.12.0"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[TensorCore]]
 deps = ["LinearAlgebra"]
@@ -936,25 +1288,32 @@ version = "0.1.1"
 [[Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[TiffImages]]
-deps = ["ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "OffsetArrays", "PkgVersion", "ProgressMeter", "UUIDs"]
-git-tree-sha1 = "c342ae2abf4902d65a0b0bf59b28506a6e17078a"
+deps = ["ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "Mmap", "OffsetArrays", "PkgVersion", "ProgressMeter", "SIMD", "UUIDs"]
+git-tree-sha1 = "bc7fd5c91041f44636b2c134041f7e5263ce58ae"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
-version = "0.5.2"
+version = "0.10.0"
 
 [[TranscodingStreams]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.6"
+version = "0.11.3"
+
+[[TriplotBase]]
+git-tree-sha1 = "4d4ed7f294cda19382ff7de4c137d24d16adc89b"
+uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
+version = "0.1.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[UnicodeFun]]
 deps = ["REPL"]
@@ -962,122 +1321,162 @@ git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
 uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 version = "0.4.1"
 
+[[Unitful]]
+deps = ["Dates", "LinearAlgebra", "Random"]
+git-tree-sha1 = "d95fe458f26209c66a187b1114df96fd70839efd"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.21.0"
+
+    [Unitful.extensions]
+    ConstructionBaseUnitfulExt = "ConstructionBase"
+    InverseFunctionsUnitfulExt = "InverseFunctions"
+
+    [Unitful.weakdeps]
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
 [[WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "de67fa59e33ad156a590055375a30b23c40299d3"
+git-tree-sha1 = "c1a7aa6219628fcd757dede0ca95e245c5cd9511"
 uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
-version = "0.5.5"
+version = "1.0.0"
 
 [[XML2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "1165b0443d0eca63ac1e32b8c0eb69ed2f4f8127"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.13.3+0"
 
 [[XSLT_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]
-git-tree-sha1 = "91844873c4085240b95e795f692c4cec4d805f8a"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "XML2_jll", "Zlib_jll"]
+git-tree-sha1 = "a54ee957f4c86b526460a720dbc882fa5edcbefc"
 uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
-version = "1.1.34+0"
+version = "1.1.41+0"
 
 [[Xorg_libX11_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
-git-tree-sha1 = "5be649d550f3f4b95308bf0183b82e2582876527"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "afead5aba5aa507ad5a3bf01f58f82c8d1403495"
 uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
-version = "1.6.9+4"
+version = "1.8.6+0"
 
 [[Xorg_libXau_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4e490d5c960c314f33885790ed410ff3a94ce67e"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6035850dcc70518ca32f012e46015b9beeda49d8"
 uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
-version = "1.0.9+4"
+version = "1.0.11+0"
 
 [[Xorg_libXdmcp_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4fe47bd2247248125c428978740e18a681372dd4"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "34d526d318358a859d7de23da945578e8e8727b7"
 uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
-version = "1.1.3+4"
+version = "1.1.4+0"
 
 [[Xorg_libXext_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
-git-tree-sha1 = "b7c0aa8c376b31e4852b360222848637f481f8c3"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "d2d1a5c49fae4ba39983f63de6afcbea47194e85"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
-version = "1.3.4+4"
+version = "1.3.6+0"
 
 [[Xorg_libXrender_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
-git-tree-sha1 = "19560f30fd49f4d4efbe7002a1037f8c43d43b96"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "47e45cd78224c53109495b3e324df0c37bb61fbe"
 uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
-version = "0.9.10+4"
+version = "0.9.11+0"
 
 [[Xorg_libpthread_stubs_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "6783737e45d3c59a4a4c4091f5f88cdcf0908cbb"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8fdda4c692503d44d04a0603d9ac0982054635f9"
 uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
-version = "0.1.0+3"
+version = "0.1.1+0"
 
 [[Xorg_libxcb_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
-git-tree-sha1 = "daf17f441228e7a3833846cd048892861cff16d6"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
+git-tree-sha1 = "bcd466676fef0878338c61e655629fa7bbc69d8e"
 uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
-version = "1.13.0+3"
+version = "1.17.0+0"
 
 [[Xorg_xtrans_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "79c31e7844f6ecf779705fbc12146eb190b7d845"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e92a1a012a10506618f10b7047e478403a046c77"
 uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
-version = "1.4.0+3"
+version = "1.5.0+0"
 
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
 
 [[isoband_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a1ac99674715995a536bbce674b068ec1b7d893d"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51b5eeb3f98367157a7a12a1fb0aa5328946c03c"
 uuid = "9a68df92-36a6-505f-a73e-abb412b6bfb4"
-version = "0.2.2+0"
+version = "0.2.3+0"
+
+[[libaom_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1827acba325fdcdf1d2647fc8d5301dd9ba43a9d"
+uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
+version = "3.9.0+0"
 
 [[libass_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "5982a94fcba20f02f42ace44b9894ee2b140fe47"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "e17c115d55c5fbb7e52ebedb427a0dca79d4484e"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.15.1+0"
+version = "0.15.2+0"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
 
 [[libfdk_aac_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "daacc84a041563f965be61859a36e17c4e4fcd55"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8a22cf860a7d27e4f3498a0fe0811a7957badb38"
 uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
-version = "2.0.2+0"
+version = "2.0.3+0"
 
 [[libpng_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "94d180a6d2b5e55e447e2d27a29ed04fe79eb30c"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "b70c870239dc3d7bc094eb2d6be9b73d27bef280"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.38+0"
+version = "1.6.44+0"
+
+[[libsixel_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "libpng_jll"]
+git-tree-sha1 = "7dfa0fd9c783d3d0cc43ea1af53d69ba45c447df"
+uuid = "075b6546-f08a-558a-be8f-8157d0f608a5"
+version = "1.10.3+1"
 
 [[libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
-git-tree-sha1 = "c45f4e40e7aafe9d086379e5578947ec8b95a8fb"
+git-tree-sha1 = "490376214c4721cdaca654041f635213c6165cb3"
 uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
-version = "1.3.7+0"
+version = "1.3.7+2"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"
+
+[[oneTBB_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7d0ea0f4895ef2f5cb83645fa689e52cb55cf493"
+uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
+version = "2021.12.0+0"
 
 [[p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"
 
 [[x264_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4fea590b89e6ec504593146bf8b988b2c00922b2"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "35976a1216d6c066ea32cba2150c4fa682b276fc"
 uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-version = "2021.5.5+0"
+version = "10164.0.0+0"
 
 [[x265_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ee567a171cce03570d77ad3a43e90218e38937a9"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dcc541bb19ed5b0ede95581fb2e41ecf179527d2"
 uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
-version = "3.5.0+0"
+version = "3.6.0+0"

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -137,8 +137,7 @@ x = LinRange(0, 1, N_samples)
 
 dims = [1, 2, 3]
 
-labels = ["Wendland C2", "Wendland C4", "Wendland C6", "Wendland C8"
-         ]
+labels = ["Wendland C2", "Wendland C4", "Wendland C6", "Wendland C8"]
 
 colors = [ColorSchemes.romaO10[end-i] for i = 1:length(labels)]
 
@@ -216,8 +215,7 @@ end
 
 function get_kernels(dim)
 
-    [ Tophat(), DoubleCosine(dim)
-    ]
+    [ Tophat(), DoubleCosine(dim)]
 
 end
 
@@ -342,6 +340,22 @@ or in the fancy way:
 
 ```julia
 d𝒲(kernel::AbstractSPHKernel, u::Real, h_inv::Real) = kernel_deriv(kernel, u, h_inv)
+```
+
+## Non-normalized kernels
+
+In some cases it may be useful to evaluate non-normalized kernels and apply the normalization at a later point. This saves some computing time in e.g. loops.
+
+For these cases you can evaluate the same functions as above, just without `h_inv`:
+
+```julia
+# non-normalized kernel value
+kernel_value(kernel::AbstractSPHKernel, u::Real)
+𝒲(kernel::AbstractSPHKernel, u::Real)
+
+# non-normalized kernel derivative
+kernel_deriv(kernel::AbstractSPHKernel, u::Real)
+d𝒲(kernel::AbstractSPHKernel, u::Real)
 ```
 
 ## Bias Correction

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -41,8 +41,7 @@ end
 
 function get_kernels(dim)
 
-    [ Cubic(dim), Quintic(dim)#, WendlandC2(dim), WendlandC4(dim), WendlandC6(dim), WendlandC8(dim)
-    ]
+    [ Cubic(dim), Quintic(dim)]
 
 end
 
@@ -51,9 +50,7 @@ x = LinRange(0, 1, N_samples)
 
 dims = [1, 2, 3]
 
-labels = ["Cubic", "Quintic", 
-         #"Wendland C2", "Wendland C4", "Wendland C6", "Wendland C8"
-         ]
+labels = ["Cubic", "Quintic"]
 
 colors = [ColorSchemes.romaO10[end-i] for i = 1:length(labels)]
 
@@ -131,8 +128,7 @@ end
 
 function get_kernels(dim)
 
-    [ WendlandC2(dim), WendlandC4(dim), WendlandC6(dim), WendlandC8(dim)
-    ]
+    [ WendlandC2(dim), WendlandC4(dim), WendlandC6(dim), WendlandC8(dim) ]
 
 end
 

--- a/docs/src/sph.md
+++ b/docs/src/sph.md
@@ -102,7 +102,7 @@ kernel_div
 or its more compact form
 
 ```@docs
-∇̇dot𝒲
+∇dot𝒲
 ```
 
 where `xᵢ` and `xⱼ` are the positions of particles `i` and `j` in 1D-3D space.

--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -74,6 +74,13 @@ module SPHKernels
     """
     𝒲( kernel::AbstractSPHKernel, u::Real, h_inv::Real) = kernel_value(kernel, u, h_inv)
 
+    """
+        𝒲( kernel::AbstractSPHKernel, u::Real)
+
+    Evaluate kernel at position ``u = \\frac{x}{h}``, without normalisation.
+    """
+    𝒲( kernel::AbstractSPHKernel, u::Real) = kernel_value(kernel, u)
+
 
     """
         d𝒲( kernel::AbstractSPHKernel, u::Real, h_inv::Real)
@@ -81,6 +88,14 @@ module SPHKernels
     Evaluate derivative at position ``u = \\frac{x}{h}``.
     """
     d𝒲(kernel::AbstractSPHKernel, u::Real, h_inv::Real) = kernel_deriv(kernel, u, h_inv)
+
+    """
+        d𝒲( kernel::AbstractSPHKernel, u::Real)
+
+    Evaluate derivative at position ``u = \\frac{x}{h}``, without normalisation.
+    """
+    d𝒲(kernel::AbstractSPHKernel, u::Real) = kernel_deriv(kernel, u)
+
 
     """ 
         δρ₁(kernel::AbstractSPHKernel, density::Real, m::Real, h_inv::Real)

--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -9,7 +9,7 @@ module SPHKernels
             bias_correction,       δρ,
             kernel_gradient,      ∇𝒲, 
             quantity_gradient,    ∇𝒜,
-            kernel_div,           ∇̇dot𝒲,
+            kernel_div,           ∇dot𝒲,
             quantity_divergence,  ∇dot𝒜,
             kernel_curl,          ∇x𝒲,
             quantity_curl,        ∇x𝒜,
@@ -151,7 +151,7 @@ module SPHKernels
                     ∇𝒜(k, r, h_inv, Δx, A_j, m_j, ρ_j)
 
                     # divergence
-                    ∇̇dot𝒲(k, h_inv, x_i, x_j, A_j)
+                    ∇dot𝒲(k, h_inv, x_i, x_j, A_j)
                     ∇dot𝒜(k, h_inv, x_i, x_j, A_j, m_j, ρ_j)
 
                     # curl 

--- a/src/bsplines/Cubic.jl
+++ b/src/bsplines/Cubic.jl
@@ -32,44 +32,58 @@ Define `Cubic` kernel with dimension `dim` for the native `DataType` of the OS.
 Cubic(dim::Integer) = Cubic(typeof(1.0), dim)
 
 """
-    kernel_value_1D(kernel::Cubic{T}, u::Real, h_inv::Real) where T
+    kernel_value_1D(kernel::Cubic{T}, u::Real) where T
 
-Evaluate cubic spline at position ``u = \\frac{x}{h}``.
+Evaluate cubic spline at position ``u = \\frac{x}{h}``, without normalisation.
 """
-function kernel_value(kernel::Cubic{T}, u::Real, h_inv::Real) where {T}
-
-    n = kernel.norm * h_inv^kernel.dim
+function kernel_value(kernel::Cubic{T}, u::Real) where {T}
 
     if u < 0.5
-        return (1 + 6 * (u - 1) * u^2) * n |> T
+        return (1 + 6 * (u - 1) * u^2) |> T
     elseif u < 1
         u_m1 = 1 - u
-        return 2u_m1^3 * n |> T
+        return 2u_m1^3 |> T
     else
         return 0.0 |> T
     end
 
 end
+
+"""
+    kernel_value_1D(kernel::Cubic{T}, u::Real, h_inv::Real) where T
+
+Evaluate cubic spline at position ``u = \\frac{x}{h}``.
+"""
+kernel_value(kernel::Cubic{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+
+"""
+    kernel_deriv(kernel::Cubic{T}, u::Real) where T
+
+Evaluate the derivative of the Cubic spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_deriv(kernel::Cubic{T}, u::Real) where {T}
+
+    if u < 0.5
+        return (u * (18u - 12)) |> T
+    elseif u < 1
+        u_m1 = 1 - u
+        return -6u_m1^2 |> T
+    else
+        return 0.0 |> T
+    end
+
+end
+
 
 """
     kernel_deriv(kernel::Cubic{T}, u::Real, h_inv::Real) where T
 
 Evaluate the derivative of the Cubic spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::Cubic{T}, u::Real, h_inv::Real) where {T}
-
-    n = kernel.norm * h_inv^(kernel.dim + 1)
-
-    if u < 0.5
-        return (u * (18u - 12)) * n |> T
-    elseif u < 1
-        u_m1 = 1 - u
-        return -6u_m1^2 * n |> T
-    else
-        return 0.0 |> T
-    end
-
-end
+kernel_deriv(kernel::Cubic{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
 
 """ 

--- a/src/sph_functions/curl.jl
+++ b/src/sph_functions/curl.jl
@@ -1,60 +1,46 @@
 """
-    kernel_curl( k::AbstractSPHKernel,       h_inv::Real, 
-                 xᵢ::Vector{<:Real}, xⱼ::Vector{<:Real},
-                 Aᵢ::Vector{<:Real}, Aⱼ::Vector{<:Real} )
+    kernel_curl(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
 
 Compute the kernel curl `∇x𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 """
-function kernel_curl( k::AbstractSPHKernel,       h_inv::Real, 
-                      xᵢ::Vector{<:Real}, xⱼ::Vector{<:Real},
-                      Aⱼ::Vector{<:Real})
-    
+function kernel_curl( k::AbstractSPHKernel, h_inv::T1, 
+                      xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
     Aⱼ × ∇𝒲(k, h_inv, xᵢ, xⱼ)
 end
 
 
 """
-    ∇x𝒲( k::AbstractSPHKernel, h_inv::Real, 
-          xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-          Aⱼ::Vector{<:Real})
+    ∇x𝒲(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
 
 Compute the kernel curl `∇x𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 """
-∇x𝒲( k::AbstractSPHKernel, h_inv::Real, 
-     xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-     Aⱼ::Vector{<:Real}) = kernel_curl( k, h_inv, xᵢ, xⱼ, Aⱼ)
+∇x𝒲(k::AbstractSPHKernel, h_inv::T1, 
+     xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_curl( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 """
-    quantity_curl( k::AbstractSPHKernel, h_inv::Real, 
-          xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-          Aⱼ::Vector{<:Real},
-          mⱼ::Real,             ρⱼ::Real )
+    quantity_curl(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, 
+                  Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
 ``∇×\\vec{A}_i(x) ≈ - \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-function quantity_curl( k::AbstractSPHKernel, h_inv::Real, 
-                        xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-                        Aⱼ::Vector{<:Real},
-                        mⱼ::Real,             ρⱼ::Real ) 
-     
+function quantity_curl( k::AbstractSPHKernel, h_inv::T1, 
+                        xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+                        mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
     (-mⱼ / ρⱼ) .* ∇x𝒲( k, h_inv, xᵢ, xⱼ, Aⱼ)
-
 end
 
 
 """
-    ∇x𝒜( k::AbstractSPHKernel, h_inv::Real, 
-          xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-          Aᵢ::Vector{<:Real},   Aⱼ::Vector{<:Real},
-          mⱼ::Real,             ρⱼ::Real )
+    ∇x𝒜(k::AbstractSPHKernel, h_inv::T1, 
+        xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+        mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
 ``∇×\\vec{A}_i(x) ≈ - \\sum_j m_j \\frac{}{\\rho_j} \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-∇x𝒜( k::AbstractSPHKernel, h_inv::Real, 
-      xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-      Aⱼ::Vector{<:Real},
-      mⱼ::Real,             ρⱼ::Real ) = quantity_curl( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)
+∇x𝒜(k::AbstractSPHKernel, h_inv::T1, 
+    xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+    mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = quantity_curl( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)

--- a/src/sph_functions/curl.jl
+++ b/src/sph_functions/curl.jl
@@ -23,7 +23,7 @@ Compute the kernel curl `∇x𝒲` between particle `i` and neighbour `j` for so
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
-``∇×\\vec{A}_i(x) ≈ - \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``∇×\\vec{A}_i(x) ≈ - \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
 function quantity_curl( k::AbstractSPHKernel, h_inv::T1, 
                         xᵢ::T2, xⱼ::T2, Aⱼ::T2,
@@ -39,7 +39,7 @@ end
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
-``∇×\\vec{A}_i(x) ≈ - \\sum_j m_j \\frac{}{\\rho_j} \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``∇×\\vec{A}_i(x) ≈ - \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
 ∇x𝒜(k::AbstractSPHKernel, h_inv::T1, 
     xᵢ::T2, xⱼ::T2, Aⱼ::T2,

--- a/src/sph_functions/curl.jl
+++ b/src/sph_functions/curl.jl
@@ -14,12 +14,10 @@ end
 
 Compute the kernel curl `∇x𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 """
-∇x𝒲(k::AbstractSPHKernel, h_inv::T1, 
-     xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_curl( k, h_inv, xᵢ, xⱼ, Aⱼ)
+∇x𝒲(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_curl( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 """
-    quantity_curl(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, 
-                  Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
+    quantity_curl(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
@@ -33,14 +31,11 @@ end
 
 
 """
-    ∇x𝒜(k::AbstractSPHKernel, h_inv::T1, 
-        xᵢ::T2, xⱼ::T2, Aⱼ::T2,
-        mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
+    ∇x𝒜(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the curl of the SPH quantity `A` for particle `i`.
 
 ``∇×\\vec{A}_i(x) ≈ - \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\times ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-∇x𝒜(k::AbstractSPHKernel, h_inv::T1, 
-    xᵢ::T2, xⱼ::T2, Aⱼ::T2,
-    mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = quantity_curl( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)
+∇x𝒜(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = 
+    quantity_curl( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)

--- a/src/sph_functions/div.jl
+++ b/src/sph_functions/div.jl
@@ -11,48 +11,37 @@ end
 
 
 """
-    ∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, 
-            xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
+    ∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
 
 Compute the kernel divergence `∇⋅𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 Compact notation of [`kernel_div`](@ref).
 """
-∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, 
-     xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_div( k, h_inv, xᵢ, xⱼ, Aⱼ)
+∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_div( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 
 """
-    quantity_divergence( k::AbstractSPHKernel, h_inv::Real, 
-                          xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-                          Aᵢ::Vector{<:Real},   Aⱼ::Vector{<:Real},
-                          mⱼ::Real,             ρⱼ::Real )
+    quantity_divergence(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the divergence of the SPH quantity `A` for particle `i`.
 
 ``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-function quantity_divergence( k::AbstractSPHKernel, h_inv::Real, 
-                              xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-                              Aⱼ::Vector{<:Real},
-                              mⱼ::Real,             ρⱼ::Real ) 
+function quantity_divergence( k::AbstractSPHKernel, h_inv::T1, 
+                              xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+                              mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
      
     mⱼ / ρⱼ * ∇dot𝒲( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 end
 
 """
-    ∇dotA( k::AbstractSPHKernel, h_inv::Real, 
-           xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-           Aᵢ::Vector{<:Real},   Aⱼ::Vector{<:Real},
-           mⱼ::Real,             ρⱼ::Real )
+    ∇dot𝒜(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the divergence of the SPH quantity `A` for particle `i`.
 Compact notation of [`quantity_divergence`](@ref).
 
 ``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-∇dot𝒜( k::AbstractSPHKernel, h_inv::Real, 
-        xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-        Aⱼ::Vector{<:Real},
-        mⱼ::Real,             ρⱼ::Real ) = quantity_divergence( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ )
+∇dot𝒜(k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = 
+    quantity_divergence( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ )
 

--- a/src/sph_functions/div.jl
+++ b/src/sph_functions/div.jl
@@ -1,29 +1,24 @@
 """
-    kernel_div( k::AbstractSPHKernel,       h_inv::Real, 
-                xᵢ::Vector{<:Real}, xⱼ::Vector{<:Real},
-                Aᵢ::Vector{<:Real}, Aⱼ::Vector{<:Real} )
+    kernel_div( k::AbstractSPHKernel, h_inv::T1, 
+                xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
 
 Compute the kernel divergence `∇⋅𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 """
-function kernel_div( k::AbstractSPHKernel,       h_inv::Real, 
-                     xᵢ::Vector{<:Real}, xⱼ::Vector{<:Real},
-                     Aⱼ::Vector{<:Real})
-    
+function kernel_div( k::AbstractSPHKernel, h_inv::T1, 
+                     xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
     Aⱼ ⋅ ∇𝒲(k, h_inv, xᵢ, xⱼ)
 end
 
 
 """
-    ∇̇dot𝒲( k::AbstractSPHKernel, h_inv::Real, 
-            xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-            Aᵢ::Vector{<:Real},   Aⱼ::Vector{<:Real})
+    ∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, 
+            xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2}
 
 Compute the kernel divergence `∇⋅𝒲` between particle `i` and neighbour `j` for some SPH quantity `A`.
 Compact notation of [`kernel_div`](@ref).
 """
-∇̇dot𝒲( k::AbstractSPHKernel, h_inv::Real, 
-     xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-     Aⱼ::Vector{<:Real}) = kernel_div( k, h_inv, xᵢ, xⱼ, Aⱼ)
+∇dot𝒲( k::AbstractSPHKernel, h_inv::T1, 
+     xᵢ::T2, xⱼ::T2, Aⱼ::T2) where {T1,T2} = kernel_div( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 
 """
@@ -41,7 +36,7 @@ function quantity_divergence( k::AbstractSPHKernel, h_inv::Real,
                               Aⱼ::Vector{<:Real},
                               mⱼ::Real,             ρⱼ::Real ) 
      
-    mⱼ / ρⱼ * ∇̇dot𝒲( k, h_inv, xᵢ, xⱼ, Aⱼ)
+    mⱼ / ρⱼ * ∇dot𝒲( k, h_inv, xᵢ, xⱼ, Aⱼ)
 
 end
 

--- a/src/sph_functions/div.jl
+++ b/src/sph_functions/div.jl
@@ -29,7 +29,7 @@ Compact notation of [`kernel_div`](@ref).
 
 Compute the contribution of particle `j` to the divergence of the SPH quantity `A` for particle `i`.
 
-``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
 function quantity_divergence( k::AbstractSPHKernel, h_inv::Real, 
                               xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
@@ -49,7 +49,7 @@ end
 Compute the contribution of particle `j` to the divergence of the SPH quantity `A` for particle `i`.
 Compact notation of [`quantity_divergence`](@ref).
 
-``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``∇\\cdot\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\cdot ∇W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
 ∇dot𝒜( k::AbstractSPHKernel, h_inv::Real, 
         xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},

--- a/src/sph_functions/gradient.jl
+++ b/src/sph_functions/gradient.jl
@@ -1,15 +1,12 @@
 
 """
-    kernel_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                     xᵢ::Union{Real, Vector{<:Real}}, 
-                     xⱼ::Union{Real, Vector{<:Real}} )
+    kernel_gradient( k::AbstractSPHKernel, h_inv::Real, xᵢ::T, xⱼ::T ) where T
 
 Computes the gradient of the kernel `k` at the position of the neighbour `xⱼ`. 
 
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
-function kernel_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                          xᵢ::T, xⱼ::T ) where T
+function kernel_gradient( k::AbstractSPHKernel, h_inv::Real, xᵢ::T, xⱼ::T ) where T
     r  = get_r(xᵢ, xⱼ)
 
     dwk_r = d𝒲(k, r*h_inv, h_inv) / r
@@ -20,8 +17,7 @@ function kernel_gradient( k::AbstractSPHKernel, h_inv::Real,
 end
 
 """
-    kernel_gradient( k::AbstractSPHKernel, r::Real, h_inv::Real, 
-                     Δx::Vector{<:Real})
+    kernel_gradient( k::AbstractSPHKernel, r::T1, h_inv::T1, Δx::T2) where {T1,T2}
 
 Computes the gradient of the kernel `k` at the distance `r` along the distance vector `Δx` of the neighbour `j`. 
 
@@ -39,15 +35,14 @@ end
 
 
 """
-    ∇𝒲( k::AbstractSPHKernel, h_inv::Real, xᵢ::Union{Real, Vector{<:Real}}, xⱼ::Union{Real, Vector{<:Real}} )
+    ∇𝒲( k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2 ) where {T1<:Real,T2}
 
 Computes the gradient of the kernel `k` at the position of the neighbour `xⱼ`. 
 Compact notation of [`kernel_gradient`](@ref).
 
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
-∇𝒲( k::AbstractSPHKernel, h_inv::T1, 
-     xᵢ::T2, xⱼ::T2 ) where {T1<:Real,T2} = kernel_gradient(k, h_inv, xᵢ, xⱼ)
+∇𝒲( k::AbstractSPHKernel, h_inv::T1, xᵢ::T2, xⱼ::T2 ) where {T1<:Real,T2} = kernel_gradient(k, h_inv, xᵢ, xⱼ)
 
 """
     ∇𝒲( k::AbstractSPHKernel, h_inv::Real, xᵢ::Union{Real, Vector{<:Real}}, xⱼ::Union{Real, Vector{<:Real}} )
@@ -63,11 +58,9 @@ Compact notation of [`kernel_gradient`](@ref).
 
 
 """
-    quantity_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                       xᵢ::Union{Real, Vector{<:Real}},   
-                       xⱼ::Union{Real, Vector{<:Real}},
-                       Aⱼ::Union{Real, Vector{<:Real}},
-                       mⱼ::Real,             ρⱼ::Real ) 
+    quantity_gradient(k::AbstractSPHKernel, h_inv::T1, 
+                      xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+                      mⱼ::T1, ρⱼ::T1 ) where {T1<:Real, T2}
 
 Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
 Based on positions `xᵢ` and `xⱼ`.
@@ -90,11 +83,10 @@ end
 
 
 """
-    quantity_gradient( k::AbstractSPHKernel, 
-                       r::Real,  h_inv::Real, 
-                       Δx::Union{Real, Vector{<:Real}},
-                       Aⱼ::Union{Real, Vector{<:Real}},
-                       mⱼ::Real, ρⱼ::Real ) 
+    quantity_gradient(k::AbstractSPHKernel,
+                      r::T1, h_inv::T1,
+                      Δx::T2, Aⱼ::T2,
+                      mⱼ::T1, ρⱼ::T1) where {T1<:Real,T2}
 
 Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
 Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
@@ -117,10 +109,7 @@ end
 
 
 """
-    ∇𝒜( k::AbstractSPHKernel, h_inv::Real, 
-        xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-        Aⱼ::Vector{<:Real},   
-        mⱼ::Real=1,           ρⱼ::Real=1 )
+    ∇𝒜( k::AbstractSPHKernel, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)
 
 Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
 Compact notation of [`quantity_gradient`](@ref).

--- a/src/sph_functions/gradient.jl
+++ b/src/sph_functions/gradient.jl
@@ -9,8 +9,7 @@ Computes the gradient of the kernel `k` at the position of the neighbour `xⱼ`.
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
 function kernel_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                          xᵢ::Vector{<:Real}, 
-                          xⱼ::Vector{<:Real} )
+                          xᵢ::T, xⱼ::T ) where T
     r  = get_r(xᵢ, xⱼ)
 
     dwk_r = d𝒲(k, r*h_inv, h_inv) / r
@@ -28,8 +27,7 @@ Computes the gradient of the kernel `k` at the distance `r` along the distance v
 
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
-function kernel_gradient( k::AbstractSPHKernel, r::Real, h_inv::Real, 
-                          Δx::Union{Real, Vector{<:Real}})
+function kernel_gradient( k::AbstractSPHKernel, r::T1, h_inv::T1, Δx::T2) where {T1,T2}
 
     dwk_r = d𝒲(k, r*h_inv, h_inv) / r
 
@@ -41,27 +39,6 @@ end
 
 
 """
-    kernel_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                     xᵢ::Union{Real, Vector{<:Real}}, 
-                     xⱼ::Union{Real, Vector{<:Real}} )
-
-Computes the gradient of the kernel `k` at the position of the neighbour `xⱼ`. 
-
-``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
-"""
-function kernel_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                          xᵢ::Real,  xⱼ::Real, )
-    
-    r  = get_r(xᵢ, xⱼ)
-
-    dwk_r = d𝒲(k, r*h_inv, h_inv) / r
-    
-    map(xᵢ, xⱼ) do i, j
-        dwk_r * (i - j)
-    end
-end
-
-"""
     ∇𝒲( k::AbstractSPHKernel, h_inv::Real, xᵢ::Union{Real, Vector{<:Real}}, xⱼ::Union{Real, Vector{<:Real}} )
 
 Computes the gradient of the kernel `k` at the position of the neighbour `xⱼ`. 
@@ -69,9 +46,8 @@ Compact notation of [`kernel_gradient`](@ref).
 
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
-∇𝒲( k::AbstractSPHKernel, h_inv::Real, 
-     xᵢ::Union{Real, Vector{<:Real}}, 
-     xⱼ::Union{Real, Vector{<:Real}} ) = kernel_gradient(k, h_inv, xᵢ, xⱼ)
+∇𝒲( k::AbstractSPHKernel, h_inv::T1, 
+     xᵢ::T2, xⱼ::T2 ) where {T1<:Real,T2} = kernel_gradient(k, h_inv, xᵢ, xⱼ)
 
 """
     ∇𝒲( k::AbstractSPHKernel, h_inv::Real, xᵢ::Union{Real, Vector{<:Real}}, xⱼ::Union{Real, Vector{<:Real}} )
@@ -83,8 +59,7 @@ Compact notation of [`kernel_gradient`](@ref).
 
 ``∇W(x_{ij}, h_i) = \\frac{dW}{dx}\\vert_{x_j} \\frac{Δx_{ij}}{||x_{ij}||} \\frac{1}{h_i}`` 
 """
-∇𝒲( k::AbstractSPHKernel, r::Real, h_inv::Real, 
-     Δx::Union{Real, Vector{<:Real}}) = kernel_gradient(k, r, h_inv, Δx )
+∇𝒲( k::AbstractSPHKernel, r::T1, h_inv::T1, Δx::T2) where {T1<:Real,T2} = kernel_gradient(k, r, h_inv, Δx )
 
 
 """
@@ -99,11 +74,9 @@ Based on positions `xᵢ` and `xⱼ`.
 
 ``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
 """
-function quantity_gradient( k::AbstractSPHKernel, h_inv::Real, 
-                            xᵢ::Union{Real, Vector{<:Real}},   
-                            xⱼ::Union{Real, Vector{<:Real}},
-                            Aⱼ::Union{Real, Vector{<:Real}},
-                            mⱼ::Real,             ρⱼ::Real ) 
+function quantity_gradient( k::AbstractSPHKernel, h_inv::T1, 
+                            xᵢ::T2, xⱼ::T2, Aⱼ::T2,
+                            mⱼ::T1, ρⱼ::T1 ) where {T1<:Real, T2}
                   
     r = get_r(xᵢ, xⱼ)
 
@@ -111,6 +84,33 @@ function quantity_gradient( k::AbstractSPHKernel, h_inv::Real,
 
     map(xᵢ, xⱼ, Aⱼ) do xi, xj, Aj
         mj_dwk_r * (xi - xj) * Aj
+    end
+
+end
+
+
+"""
+    quantity_gradient( k::AbstractSPHKernel, 
+                       r::Real,  h_inv::Real, 
+                       Δx::Union{Real, Vector{<:Real}},
+                       Aⱼ::Union{Real, Vector{<:Real}},
+                       mⱼ::Real, ρⱼ::Real ) 
+
+Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
+Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
+Useful if many quantities need to be computed for the same particle pair.
+
+``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
+"""
+function quantity_gradient(k::AbstractSPHKernel,
+                           r::T1, h_inv::T1,
+                           Δx::T2, Aⱼ::T2,
+                           mⱼ::T1, ρⱼ::T1) where {T1<:Real,T2}
+
+    mj_dwk_r = mⱼ / (ρⱼ * r) * d𝒲(k, r * h_inv, h_inv)
+
+    map(Δx, Aⱼ) do dx, Aj
+        mj_dwk_r * dx * Aj
     end
 
 end
@@ -127,76 +127,4 @@ Compact notation of [`quantity_gradient`](@ref).
 
 ``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
 """
-∇𝒜( k::AbstractSPHKernel, h_inv::Real, 
-     xᵢ::Union{Real, Vector{<:Real}},   xⱼ::Union{Real, Vector{<:Real}},
-     Aⱼ::Union{Real, Vector{<:Real}},
-     mⱼ::Real,             ρⱼ::Real  ) = quantity_gradient( k, h_inv, 
-                                                            xᵢ, xⱼ, 
-                                                            Aⱼ, mⱼ, ρⱼ)
-
-"""
-    quantity_gradient( k::AbstractSPHKernel, 
-                       r::Real,  h_inv::Real, 
-                       Δx::Union{Real, Vector{<:Real}},
-                       Aⱼ::Union{Real, Vector{<:Real}},
-                       mⱼ::Real, ρⱼ::Real ) 
-
-Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
-Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
-Useful if many quantities need to be computed for the same particle pair.
-
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
-"""
-function quantity_gradient( k::AbstractSPHKernel, 
-                            r::Real,  h_inv::Real, 
-                            Δx::Union{Real, Vector{<:Real}},
-                            Aⱼ::Union{Real, Vector{<:Real}},
-                            mⱼ::Real, ρⱼ::Real ) 
-
-    mj_dwk_r = mⱼ / (ρⱼ * r) * d𝒲(k, r * h_inv, h_inv)
-
-    map(Δx, Aⱼ) do dx, Aj
-        mj_dwk_r * dx * Aj
-    end
-
-end
-
-
-"""
-    ∇𝒜( k::AbstractSPHKernel, 
-         r::Real,  h_inv::Real, 
-         Δx::Union{Real, Vector{<:Real}},
-         Aⱼ::Union{Real, Vector{<:Real}},
-         mⱼ::Real, ρⱼ::Real )
-
-Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
-Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
-Useful if many quantities need to be computed for the same particle pair.
-
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
-"""
-∇𝒜( k::AbstractSPHKernel, 
-     r::Real,  h_inv::Real, 
-     Δx::Union{Real, Vector{<:Real}},
-     Aⱼ::Vector{<:Real},
-     mⱼ::Real, ρⱼ::Real )  = quantity_gradient( k, r, h_inv, Δx, Aⱼ, mⱼ, ρⱼ)
-
-
-"""
-    ∇𝒜( k::AbstractSPHKernel, 
-         r::Real,  h_inv::Real, 
-         Δx::Union{Real, Vector{<:Real}},
-         Aⱼ::Union{Real, Vector{<:Real}},
-         mⱼ::Real, ρⱼ::Real )
-
-Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
-Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
-Useful if many quantities need to be computed for the same particle pair.
-
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
-"""
-∇𝒜( k::AbstractSPHKernel, 
-     r::Real,  h_inv::Real, 
-     Δx::Union{Real, Vector{<:Real}},
-     Aⱼ::Real,
-     mⱼ::Real, ρⱼ::Real )  = Aⱼ * mⱼ / (ρⱼ * r) * d𝒲(k, r * h_inv, h_inv)
+∇𝒜( k::AbstractSPHKernel, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ) = quantity_gradient( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)

--- a/src/sph_functions/gradient.jl
+++ b/src/sph_functions/gradient.jl
@@ -72,7 +72,7 @@ Compact notation of [`kernel_gradient`](@ref).
 Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
 Based on positions `xᵢ` and `xⱼ`.
 
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
+``∇\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\: ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
 """
 function quantity_gradient( k::AbstractSPHKernel, h_inv::T1, 
                             xᵢ::T2, xⱼ::T2, Aⱼ::T2,
@@ -100,7 +100,7 @@ Compute the contribution of particle `j` to the gradient of the SPH quantity `A`
 Based on Euclidean distance `r` and distance vector `Δx` between the particles. 
 Useful if many quantities need to be computed for the same particle pair.
 
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
+``∇\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\: ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
 """
 function quantity_gradient(k::AbstractSPHKernel,
                            r::T1, h_inv::T1,
@@ -125,6 +125,6 @@ end
 Compute the contribution of particle `j` to the gradient of the SPH quantity `A` for particle `i`.
 Compact notation of [`quantity_gradient`](@ref).
 
-``∇\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
+``∇\\vec{A}_i(x) ≈ \\sum_j \\frac{m_j}{\\rho_j} \\vec{A}_j \\: ∇W(||\\vec{x}_i - \\vec{x}_j||, h_i)``
 """
 ∇𝒜( k::AbstractSPHKernel, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ) = quantity_gradient( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)

--- a/src/sph_functions/quantity.jl
+++ b/src/sph_functions/quantity.jl
@@ -4,7 +4,7 @@
 
 Computes the value of the kernel `k` at the position of the neighbour `xⱼ`. 
 
-``W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``W(x_i - x_j, h_i)``
 """
 function kernel_value( k::AbstractSPHKernel, h_inv::Real, 
                        xᵢ::Real, xⱼ::Real ) 
@@ -15,16 +15,15 @@ function kernel_value( k::AbstractSPHKernel, h_inv::Real,
 end
 
 """
-    kernel_value( k::AbstractSPHKernel, h_inv::Real, 
-                  xᵢ::Union{Real, Vector{<:Real}}, 
-                  xⱼ::Union{Real, Vector{<:Real}} )
+    kernel_value( k::AbstractSPHKernel, h_inv::T1, 
+                       xᵢ::T2, xⱼ::T2 ) where {T1,T2}
 
 Computes the value of the kernel `k` at the position of the neighbour `xⱼ`. 
 
 ``W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-function kernel_value( k::AbstractSPHKernel, h_inv::Real, 
-                       xᵢ::Vector{<:Real}, xⱼ::Vector{<:Real} )
+function kernel_value( k::AbstractSPHKernel, h_inv::T1, 
+                       xᵢ::T2, xⱼ::T2 ) where {T1,T2}
     
     u  = get_r(xᵢ, xⱼ) * h_inv
 
@@ -33,25 +32,17 @@ end
 
 
 """
-    𝒜( k::AbstractSPHKernel, h_inv::Real, 
-        xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-        Aᵢ::Vector{<:Real},   Aⱼ::Vector{<:Real},
-        mⱼ::Real,             ρⱼ::Real )
+    𝒲( k::AbstractSPHKernel, h_inv, xᵢ, xⱼ)
 
-Compute the contribution of particle `j` to the SPH quantity `A` for particle `i`.
+Computes the value of the kernel `k` at the position of the neighbour `xⱼ`. 
 
-See e.g. Price 2012:
-``\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} W(\\vec{x}_i - \\vec{x}_j, h_i)``
+``W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-𝒲( k::AbstractSPHKernel, h_inv::Real, 
-    xᵢ::Union{Real, Vector{<:Real}}, 
-    xⱼ::Union{Real, Vector{<:Real}}) = kernel_value( k, h_inv, xᵢ, xⱼ)
+𝒲( k::AbstractSPHKernel, h_inv, xᵢ, xⱼ) = kernel_value( k, h_inv, xᵢ, xⱼ)
 
 """
-    kernel_quantity( k::AbstractSPHKernel, h_inv::Real, 
-                     xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-                     Aⱼ::Vector{<:Real},
-                     mⱼ::Real,             ρⱼ::Real )
+    kernel_quantity(k::AbstractSPHKernel, r::T1, h_inv::T1, 
+                    Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the SPH quantity `A` for particle `i`.
 Based on Euclidean distance `r` between the particles. 
@@ -59,10 +50,8 @@ Useful if many quantities need to be computed for the same particle pair.
 
 ``\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-function kernel_quantity( k::AbstractSPHKernel, 
-                          r::Real, h_inv::Real, 
-                          Aⱼ::Union{Real, Vector{<:Real}},
-                          mⱼ::Real,             ρⱼ::Real ) 
+function kernel_quantity( k::AbstractSPHKernel, r::T1, h_inv::T1, 
+                          Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
                  
     mj_wk = mⱼ / ρⱼ * 𝒲(k, r*h_inv, h_inv)
 
@@ -73,21 +62,16 @@ end
 
 
 """
-    kernel_quantity( k::AbstractSPHKernel, h_inv::Real, 
-                     xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-                     Aⱼ::Vector{<:Real},
-                     mⱼ::Real,             ρⱼ::Real )
+    kernel_quantity(k::AbstractSPHKernel, h_inv::T1, 
+                    xᵢ::T2, xⱼ::T2, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the SPH quantity `A` for particle `i`.
 Based on positions `xᵢ` and `xⱼ`.
 
 ``\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-function kernel_quantity( k::AbstractSPHKernel, h_inv::Real, 
-                 xᵢ::Union{Real, Vector{<:Real}}, 
-                 xⱼ::Union{Real, Vector{<:Real}},
-                 Aⱼ::Union{Real, Vector{<:Real}},
-                 mⱼ::Real,             ρⱼ::Real )
+function kernel_quantity(k::AbstractSPHKernel, h_inv::T1, 
+                         xᵢ::T2, xⱼ::T2, Aⱼ::Union{T1,T2}, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
                  
     mj_wk = mⱼ / ρⱼ * kernel_value( k, h_inv, xᵢ, xⱼ)
 
@@ -98,28 +82,22 @@ end
 
 
 """
-    𝒜( k::AbstractSPHKernel, h_inv::Real, 
-        xᵢ::Vector{<:Real},   xⱼ::Vector{<:Real},
-        Aⱼ::Vector{<:Real},
-        mⱼ::Real,             ρⱼ::Real )
+    𝒜(k::AbstractSPHKernel, h_inv::T1, 
+      xᵢ::Union{T1, T2}, xⱼ::Union{T1, T2},
+      Aⱼ::Union{T1, T2}, mⱼ::T1, ρⱼ::T1 ) where {T1,T2} 
 
 Compute the contribution of particle `j` to the SPH quantity `A` for particle `i`.
 Based on positions `xᵢ` and `xⱼ`.
 
 ``\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} W(\\vec{x}_i - \\vec{x}_j, h_i)``
 """
-𝒜( k::AbstractSPHKernel, h_inv::Real, 
-    xᵢ::Union{Real, Vector{<:Real}}, 
-    xⱼ::Union{Real, Vector{<:Real}},
-    Aⱼ::Union{Real, Vector{<:Real}},
-    mⱼ::Real,             ρⱼ::Real ) = kernel_quantity( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)
+𝒜( k::AbstractSPHKernel, h_inv::T1, 
+    xᵢ::Union{T1, T2}, xⱼ::Union{T1, T2},
+    Aⱼ::Union{T1, T2}, mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = kernel_quantity( k, h_inv, xᵢ, xⱼ, Aⱼ, mⱼ, ρⱼ)
 
 
 """
-    𝒜( k::AbstractSPHKernel, 
-        r::Real,  h_inv::Real, 
-        Aⱼ::Union{Real, Vector{<:Real}},
-        mⱼ::Real, ρⱼ::Real )
+    𝒜(k::AbstractSPHKernel, r::T1,  h_inv::T1, Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2}
 
 Compute the contribution of particle `j` to the SPH quantity `A` for particle `i`.
 Based on Euclidean distance `r` between the particles. 
@@ -127,7 +105,5 @@ Useful if many quantities need to be computed for the same particle pair.
 
 ``\\vec{A}_i(x) ≈ \\sum_j m_j \\frac{\\vec{A}_j}{\\rho_j} W(r, h_i)``
 """
-𝒜( k::AbstractSPHKernel, 
-    r::Real,  h_inv::Real, 
-    Aⱼ::Union{Real, Vector{<:Real}},
-    mⱼ::Real, ρⱼ::Real ) = kernel_quantity( k, r, h_inv, Aⱼ, mⱼ, ρⱼ)
+𝒜(k::AbstractSPHKernel, r::T1,  h_inv::T1, 
+  Aⱼ::T2, mⱼ::T1, ρⱼ::T1 ) where {T1,T2} = kernel_quantity( k, r, h_inv, Aⱼ, mⱼ, ρⱼ)

--- a/src/tophat/tophat.jl
+++ b/src/tophat/tophat.jl
@@ -10,11 +10,11 @@ Define `Tophat` kernel with dimension `dim` for the native `DataType` of the OS.
 Tophat(value::Real=1.0) = Tophat{typeof(value)}(value)
 
 """
-    kernel_value(kernel::Tophat{T}, u::Real, h_inv::Real) where T
+    kernel_value(kernel::Tophat{T}, u::Real) where T
 
-Evaluate Tophat spline at position ``u = \\frac{x}{h}``.
+Evaluate Tophat spline at position ``u = \\frac{x}{h}``, without normalisation.
 """
-function kernel_value(kernel::Tophat{T}, u::Real, h_inv::Real) where {T}
+function kernel_value(kernel::Tophat{T}, u::Real) where {T}
     if u < 1
         return kernel.value
     else
@@ -23,14 +23,30 @@ function kernel_value(kernel::Tophat{T}, u::Real, h_inv::Real) where {T}
 end
 
 """
+    kernel_value(kernel::Tophat{T}, u::Real, h_inv::Real) where T
+
+Evaluate Tophat spline at position ``u = \\frac{x}{h}``.
+"""
+kernel_value(kernel::Tophat{T}, u::Real, h_inv::Real) where {T} = 
+    kernel_value(kernel, u)
+
+"""
+    kernel_deriv_1D(kernel::Tophat{T}, u::Real) where T
+
+Evaluate the derivative of the Tophat spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_deriv(kernel::Tophat{T}, u::Real) where {T}
+    return 0 |> T 
+end
+
+
+"""
     kernel_deriv_1D(kernel::Tophat{T}, u::Real, h_inv::Real) where T
 
 Evaluate the derivative of the Tophat spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::Tophat{T}, u::Real, h_inv::Real) where {T}
-    return 0 |> T 
-end
-
+kernel_deriv(kernel::Tophat{T}, u::Real, h_inv::Real) where {T} = 
+    kernel_deriv(kernel, u)
 
 """ 
     bias_correction(kernel::Tophat{T},

--- a/src/trigonometric/double_cosine.jl
+++ b/src/trigonometric/double_cosine.jl
@@ -42,36 +42,50 @@ Define `DoubleCosine` kernel with dimension `dim` for the native `DataType` of t
 DoubleCosine(dim::Integer) = DoubleCosine(typeof(1.0), dim)
 
 """
-    kernel_value(kernel::DoubleCosine, u::Real, h_inv::Real)
-Evaluate DoubleCosine spline at position ``u = \\frac{x}{h}``.
+    kernel_value(kernel::DoubleCosine, u::Real)
+
+Evaluate DoubleCosine spline at position ``u = \\frac{x}{h}``, without normalisation.
 """
-function kernel_value(kernel::DoubleCosine{T}, u::Real, h_inv::Real) where {T}
+function kernel_value(kernel::DoubleCosine{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^kernel.dim
-        return (4 * cos(π * u) + cos(2π * u) + 3) * n
+        return (4 * cos(π * u) + cos(2π * u) + 3)
     else
         return 0 |> T
     end
 
 end
 
+"""
+    kernel_value(kernel::DoubleCosine, u::Real, h_inv::Real)
+Evaluate DoubleCosine spline at position ``u = \\frac{x}{h}``.
+"""
+kernel_value(kernel::DoubleCosine{T}, u::Real, h_inv::Real) where {T} =
+    T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+
+"""
+    kernel_deriv(kernel::DoubleCosine, u::Real)
+
+Evaluate the derivative of the DoubleCosine spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_deriv(kernel::DoubleCosine{T}, u::Real) where {T}
+
+    if u < 1
+        return (-4π * sin(π * u) - 2π * sin(2π * u))
+    else
+        return 0 |> T
+    end
+
+end
 
 """
     kernel_deriv(kernel::DoubleCosine, u::Real, h_inv::Real)
 
 Evaluate the derivative of the DoubleCosine spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::DoubleCosine{T}, u::Real, h_inv::Real) where {T}
-
-    if u < 1
-        n = kernel.norm * h_inv^kernel.dim * h_inv
-        return (-4π * sin(π * u) - 2π * sin(2π * u)) * n
-    else
-        return 0 |> T
-    end
-
-end
+kernel_deriv(kernel::DoubleCosine{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
 
 """ 

--- a/src/wendland/C2.jl
+++ b/src/wendland/C2.jl
@@ -37,17 +37,40 @@ Define `WendlandC2` kernel with dimension `dim` for the native `DataType` of the
 WendlandC2(dim::Integer) = WendlandC2(typeof(1.0), dim)
 
 """
+    kernel_value(kernel::WendlandC2_1D{T}, u::Real) where T
+
+Evaluate WendlandC2 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_value(kernel::WendlandC2_1D{T}, u::Real) where {T}
+
+    if u < 1
+        t1 = 1 - u
+        t3 = t1 * t1 * t1
+        return (t3 * (1 + 3u)) |> T
+    else
+        return 0 |> T
+    end
+
+end
+
+"""
     kernel_value(kernel::WendlandC2_1D{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC2 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC2_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC2_1D{T}, u::Real, h_inv::Real) where {T} =
+    T(kernel.norm * h_inv) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv_1D(kernel::WendlandC2{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC2 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC2_1D{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv
         t1 = 1 - u
-        t3 = t1 * t1 * t1
-        return (t3 * (1 + 3u)) * n |> T
+        return (-12u * t1^2) |> T
     else
         return 0 |> T
     end
@@ -59,31 +82,46 @@ end
 
 Evaluate the derivative of the WendlandC2 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC2_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_deriv(kernel::WendlandC2_1D{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^2) * kernel_deriv(kernel, u)
+
+
+"""
+    kernel_value(kernel::WendlandC2{T}, u::Real, h_inv::Real) where T
+
+Evaluate WendlandC2 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_value(kernel::WendlandC2{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^2
         t1 = 1 - u
-        return (-12u * t1^2) * n |> T
+        t4 = t1 * t1 * t1 * t1
+        return (t4 * (1 + 4u)) |> T
     else
         return 0 |> T
     end
 
 end
 
-
 """
     kernel_value(kernel::WendlandC2{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC2 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC2{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC2{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv(kernel::WendlandC2{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC2 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC2{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^kernel.dim
         t1 = 1 - u
-        t4 = t1 * t1 * t1 * t1
-        return (t4 * (1 + 4u)) * n |> T
+        t3 = t1 * t1 * t1
+        return (-20u * t3) |> T
     else
         return 0 |> T
     end
@@ -95,19 +133,8 @@ end
 
 Evaluate the derivative of the WendlandC2 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC2{T}, u::Real, h_inv::Real) where {T}
-
-    if u < 1
-        n = kernel.norm * h_inv^kernel.dim * h_inv
-        t1 = 1 - u
-        t3 = t1 * t1 * t1
-        return (-20u * t3) * n |> T
-    else
-        return 0 |> T
-    end
-
-end
-
+kernel_deriv(kernel::WendlandC2{T}, u::Real, h_inv::Real) where {T} = 
+    T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
 """ 
     bias_correction( kernel::Union{WendlandC2_1D{T}, WendlandC2{T}}, 

--- a/src/wendland/C4.jl
+++ b/src/wendland/C4.jl
@@ -37,17 +37,42 @@ Define `WendlandC4` kernel with dimension `dim` for the native `DataType` of the
 WendlandC4(dim::Integer) = WendlandC4(typeof(1.0), dim)
 
 """
+    kernel_value(kernel::WendlandC4{T}, u::Real) where T
+
+Evaluate WendlandC4 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_value(kernel::WendlandC4_1D{T}, u::Real) where {T}
+
+    if u < 1
+        t1 = 1 - u
+        t5 = t1 * t1 * t1 * t1 * t1
+        return (t5 * (1 + 5u + 8u^2)) |> T
+    else
+        return 0 |> T
+    end
+
+end
+
+
+"""
     kernel_value(kernel::WendlandC4{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC4 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC4_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC4_1D{T}, 
+        u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv(kernel::WendlandC4_1D{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC4 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC4_1D{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv
         t1 = 1 - u
-        t5 = t1 * t1 * t1 * t1 * t1
-        return (t5 * (1 + 5u + 8u^2)) * n |> T
+        t4 = t1 * t1 * t1 * t1
+        return (-14u * t4 - 56u^2 * t4) |> T
     else
         return 0 |> T
     end
@@ -59,13 +84,21 @@ end
 
 Evaluate the derivative of the WendlandC4 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC4_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_deriv(kernel::WendlandC4_1D{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^2) * kernel_deriv(kernel, u)
+
+
+"""
+    (kernel::WendlandC4{T}, u::Real) where T
+
+Evaluate WendlandC4 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_value(kernel::WendlandC4{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^2
         t1 = 1 - u
-        t4 = t1 * t1 * t1 * t1
-        return (-14u * t4 - 56u^2 * t4) * n |> T
+        t5 = t1 * t1 * t1 * t1 * t1
+        return (t1 * t5 * (1 + 6u + 35 / 3 * u^2)) |> T
     else
         return 0 |> T
     end
@@ -78,13 +111,20 @@ end
 
 Evaluate WendlandC4 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC4{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC4{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv_2D(kernel::WendlandC4{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC4 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC4{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^kernel.dim
         t1 = 1 - u
         t5 = t1 * t1 * t1 * t1 * t1
-        return (t1 * t5 * (1 + 6u + 35 / 3 * u^2)) * n |> T
+        return (-288 / 3 * t5 * u^2 - 56 / 3 * u * t5) |> T
     else
         return 0 |> T
     end
@@ -96,18 +136,8 @@ end
 
 Evaluate the derivative of the WendlandC4 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC4{T}, u::Real, h_inv::Real) where {T}
-
-    if u < 1
-        n = kernel.norm * h_inv^kernel.dim * h_inv
-        t1 = 1 - u
-        t5 = t1 * t1 * t1 * t1 * t1
-        return (-288 / 3 * t5 * u^2 - 56 / 3 * u * t5) * n |> T
-    else
-        return 0 |> T
-    end
-
-end
+kernel_deriv(kernel::WendlandC4{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
 
 """ 

--- a/src/wendland/C6.jl
+++ b/src/wendland/C6.jl
@@ -39,16 +39,40 @@ WendlandC6(dim::Integer) = WendlandC6(typeof(1.0), dim)
 """
     kernel_value(kernel::WendlandC6_1D{T}, u::Real, h_inv::Real) where T
 
-Evaluate WendlandC6 spline at position ``u = \\frac{x}{h}``.
+Evaluate WendlandC6 spline at position ``u = \\frac{x}{h}`` without normalisation.
 """
-function kernel_value(kernel::WendlandC6_1D{T}, u::Real, h_inv::Real) where {T}
+function kernel_value(kernel::WendlandC6_1D{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv
         t1 = 1 - u
         t6 = t1 * t1 * t1 * t1 * t1 * t1
         u2 = u * u
-        return (t6 * t1 * (1 + 7u + 19u2 + 21u2 * u)) * n |> T
+        return (t6 * t1 * (1 + 7u + 19u2 + 21u2 * u)) |> T
+    else
+        return 0 |> T
+    end
+end
+
+"""
+    kernel_value(kernel::WendlandC6_1D{T}, u::Real, h_inv::Real) where T
+
+Evaluate WendlandC6 spline at position ``u = \\frac{x}{h}``.
+"""
+kernel_value(kernel::WendlandC6_1D{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv(kernel::WendlandC6_1D{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC6 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC6_1D{T}, u::Real) where {T}
+
+    if u < 1
+        t1 = 1 - u
+        t6 = t1 * t1 * t1 * t1 * t1 * t1
+        u2 = u * u
+        return (-6t6 * u * (35u2 + 18u + 1)) |> T
     else
         return 0 |> T
     end
@@ -60,36 +84,50 @@ end
 
 Evaluate the derivative of the WendlandC6 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC6_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_deriv(kernel::WendlandC6_1D{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^2) *kernel_deriv(kernel, u)
+
+
+"""
+    kernel_value(kernel::WendlandC6{T}, u::Real) where T
+
+Evaluate WendlandC6 spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_value(kernel::WendlandC6{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^2
         t1 = 1 - u
-        t6 = t1 * t1 * t1 * t1 * t1 * t1
+        t1 = t1 * t1  # (1.0 - u)^2
+        t1 = t1 * t1  # (1.0 - u)^4
+        t1 = t1 * t1  # (1.0 - u)^8
         u2 = u * u
-        return (-6t6 * u * (35u2 + 18u + 1)) * n |> T
+        return (t1 * (1 + 8u + 25u2 + 32u2 * u)) |> T
     else
         return 0 |> T
     end
 
 end
 
-
 """
     kernel_value(kernel::WendlandC6{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC6 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC6{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC6{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv(kernel::WendlandC6, u::Real)
+
+Evaluate the derivative of the WendlandC6 spline at position ``u = \\frac{x}{h}`` without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC6{T}, u::Real) where {T}
+
 
     if u < 1
-        n = kernel.norm * h_inv^kernel.dim
         t1 = 1 - u
-        t1 = t1 * t1  # (1.0 - u)^2
-        t1 = t1 * t1  # (1.0 - u)^4
-        t1 = t1 * t1  # (1.0 - u)^8
-        u2 = u * u
-        return (t1 * (1 + 8u + 25u2 + 32u2 * u)) * n |> T
+        t7 = t1 * t1 * t1 * t1 * t1 * t1 * t1
+        return (-22t7 * u * (16 * u^2 + 7u + 1)) |> T
     else
         return 0 |> T
     end
@@ -101,19 +139,8 @@ end
 
 Evaluate the derivative of the WendlandC6 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC6{T}, u::Real, h_inv::Real) where {T}
-
-
-    if u < 1
-        n = kernel.norm * h_inv^kernel.dim * h_inv
-        t1 = 1 - u
-        t7 = t1 * t1 * t1 * t1 * t1 * t1 * t1
-        return (-22t7 * u * (16 * u^2 + 7u + 1)) * n |> T
-    else
-        return 0 |> T
-    end
-
-end
+kernel_deriv(kernel::WendlandC6{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
 
 """ 

--- a/src/wendland/C8.jl
+++ b/src/wendland/C8.jl
@@ -39,18 +39,44 @@ WendlandC8(dim::Integer) = WendlandC8(typeof(1.0), dim)
 
 
 """
+    kernel_value(kernel::WendlandC8_1D{T}, u::Real) where T
+
+Evaluate WendlandC8 spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_value(kernel::WendlandC8_1D{T}, u::Real) where {T}
+
+    if u < 1
+        t1 = 1 - u
+        t8 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1
+        u2 = u * u
+        return (t8 * t1 * (384u2 * u2 + 43u2 * u + 2237u2 + 63u + 7)) |> T
+    else
+        return 0 |> T
+    end
+
+end
+
+"""
     kernel_value(kernel::WendlandC8_1D{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC8 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC8_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC8_1D{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv) * kernel_value(kernel, u)
+
+
+"""
+    kernel_deriv(kernel::WendlandC8_1D{T}, u::Real, h_inv::Real) where T
+
+Evaluate the derivative of the WendlandC8 spline at position ``u = \\frac{x}{h}``.
+"""
+function kernel_deriv(kernel::WendlandC8_1D{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv
         t1 = 1 - u
         t8 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1
         u2 = u * u
-        return (t8 * t1 * (384u2 * u2 + 43u2 * u + 2237u2 + 63u + 7)) * n |> T
+        return (-156t8 * u * (32u2 * u + 25u2 + 8u + 1)) |> T
     else
         return 0 |> T
     end
@@ -62,34 +88,48 @@ end
 
 Evaluate the derivative of the WendlandC8 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC8_1D{T}, u::Real, h_inv::Real) where {T}
+kernel_deriv(kernel::WendlandC8_1D{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^2) * kernel_deriv(kernel, u)
+
+
+"""
+    kernel_value(kernel::WendlandC8{T}, u::Real) where T
+
+Evaluate WendlandC8 spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_value(kernel::WendlandC8{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^2
         t1 = 1 - u
-        t8 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1
+        t9 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1  # (1.0 - u)^9
         u2 = u * u
-        return (-156t8 * u * (32u2 * u + 25u2 + 8u + 1)) * n |> T
+        return (t1 * t9 * (5 + 50u + 210u2 + 450u2 * u + 429u2 * u2)) |> T
     else
         return 0 |> T
     end
 
 end
 
-
 """
     kernel_value(kernel::WendlandC8{T}, u::Real, h_inv::Real) where T
 
 Evaluate WendlandC8 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_value(kernel::WendlandC8{T}, u::Real, h_inv::Real) where {T}
+kernel_value(kernel::WendlandC8{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim) * kernel_value(kernel, u)
+
+"""
+    kernel_deriv_2D(kernel::WendlandC8{T}, u::Real) where T
+
+Evaluate the derivative of the WendlandC8 spline at position ``u = \\frac{x}{h}``, without normalisation.
+"""
+function kernel_deriv(kernel::WendlandC8{T}, u::Real) where {T}
 
     if u < 1
-        n = kernel.norm * h_inv^kernel.dim
-        t1 = 1 - u
+        t1 = 1.0 - u
         t9 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1  # (1.0 - u)^9
         u2 = u * u
-        return (t1 * t9 * (5 + 50u + 210u2 + 450u2 * u + 429u2 * u2)) * n |> T
+        return -26t9 * u * (231u2 * u + 159u2 + 45u + 5) |> T
     else
         return 0 |> T
     end
@@ -101,19 +141,9 @@ end
 
 Evaluate the derivative of the WendlandC8 spline at position ``u = \\frac{x}{h}``.
 """
-function kernel_deriv(kernel::WendlandC8{T}, u::Real, h_inv::Real) where {T}
+kernel_deriv(kernel::WendlandC8{T}, 
+    u::Real, h_inv::Real) where {T} = T(kernel.norm * h_inv^kernel.dim * h_inv) * kernel_deriv(kernel, u)
 
-    if u < 1
-        n = kernel.norm * h_inv^kernel.dim * h_inv
-        t1 = 1.0 - u
-        t9 = t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1 * t1  # (1.0 - u)^9
-        u2 = u * u
-        return -26t9 * u * (231u2 * u + 159u2 + 45u + 5) * n |> T
-    else
-        return 0 |> T
-    end
-
-end
 
 """ 
     bias_correction(kernel::WendlandC8, density::Real, m::Real, h_inv::Real)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -734,6 +734,7 @@ using SPHKernels, Test
 
             k = WendlandC6()
             @test 𝒲(k, 0.5, 1.0) ≈ kernel_value(k, 0.5, 1.0)
+            @test 𝒲(k, 0.5) ≈ kernel_value(k, 0.5)
 
             @test 𝒲(k, 1.0, [0.0, 0.0, 0.0], [0.5, 0.0, 0.0]) ≈ kernel_value(k, 0.5, 1.0)
 
@@ -743,6 +744,7 @@ using SPHKernels, Test
         @testset "kernel derivative" begin
             k = WendlandC6()
             @test d𝒲(k, 0.5, 1.0) ≈ kernel_deriv(k, 0.5, 1.0)
+            @test d𝒲(k, 0.5) ≈ kernel_deriv(k, 0.5)
         end
 
         @testset "bias correction" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -715,7 +715,7 @@ using SPHKernels, Test
 
         @testset "Divergence" begin
             # kernel 
-            @test ∇̇dot𝒲(k, h_inv, x_i, x_j, A_j)           ≈ 0.004962925065655849
+            @test ∇dot𝒲(k, h_inv, x_i, x_j, A_j)           ≈ 0.004962925065655849
             # quantity
             @test ∇dot𝒜(k, h_inv, x_i, x_j, A_j, m_j, ρ_j) ≈ 0.004962925065655849
         end


### PR DESCRIPTION
Adresses issues #31 and #32:
- Type declarations are more general to allow for usage of `StaticArray` and `Tuple` in the SPH functions (#31)
- Kernel evaluations are split between with and without normalisation to allow for normalisation after a loop to improve performance (#32)

To Do:

- [x] Update Documentation